### PR TITLE
ci: dokploy auto deploy for preview

### DIFF
--- a/.github/workflows/preview-docker-ci.yaml
+++ b/.github/workflows/preview-docker-ci.yaml
@@ -107,3 +107,9 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKER_HUB_REPO }}-frontend:preview
+
+      - name: Trigger Dokploy Auto-Deploy
+        run: |
+          curl -X GET "${{ secrets.DOKPLOY_PREVIEW_AUTO_DEPLOY_WEBHOOK_URL }}" \
+            -H "accept: application/json" \
+            -H "x-api-key: ${{ secrets.DOKPLOY_API_TOKEN }}"


### PR DESCRIPTION
- Add Dokploy API trigger step after Docker image build
- Use GET request with x-api-key authentication
- Require DOKPLOY_API_TOKEN and DOKPLOY_PREVIEW_AUTO_DEPLOY_WEBHOOK_URL secrets