### PR TITLE
Potential fix for code scanning alert no. 35: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/server/internal/service/sde.go
+++ b/server/internal/service/sde.go
@@ -294,6 +294,27 @@ func isZipMagic(magic []byte) bool {
 		magic[2] == 0x03 && magic[3] == 0x04
 }
 
+// safeJoin 构造位于 destDir 下的安全路径，防止路径遍历
+func safeJoin(destDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("invalid empty file name in archive")
+	}
+	// 只保留最终文件名，丢弃任何目录部分
+	base := filepath.Base(name)
+	if base == "." || base == string(filepath.Separator) {
+		return "", fmt.Errorf("invalid file name in archive: %q", name)
+	}
+	// 基于安全的 base 名构造输出路径
+	outPath := filepath.Join(destDir, base)
+	// 规范化并确保仍然位于目标目录下
+	cleanDest := filepath.Clean(destDir)
+	cleanOut := filepath.Clean(outPath)
+	if !strings.HasPrefix(cleanOut+string(filepath.Separator), cleanDest+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry resolves outside destination directory: %q", name)
+	}
+	return outPath, nil
+}
+
 // extractGzip 解压 gzip 文件，输出文件名去掉 .gz 后缀
 func extractGzip(srcPath, destDir string) (string, error) {
 	f, err := os.Open(srcPath)
@@ -313,7 +334,10 @@ func extractGzip(srcPath, destDir string) (string, error) {
 	if outName == "" {
 		outName = strings.TrimSuffix(filepath.Base(srcPath), ".gz")
 	}
-	outPath := filepath.Join(destDir, filepath.Base(outName))
+	outPath, err := safeJoin(destDir, outName)
+	if err != nil {
+		return "", err
+	}
 	out, err := os.Create(outPath)
 	if err != nil {
 		return "", err
@@ -367,7 +391,11 @@ func extractZip(srcPath, destDir string) (string, error) {
 		if !strings.Contains(name, ".sql") {
 			continue
 		}
-		outPath := filepath.Join(destDir, filepath.Base(f.Name))
+		outPath, err := safeJoin(destDir, f.Name)
+		if err != nil {
+			// 非法路径，跳过该条目继续寻找其他 SQL 文件
+			continue
+		}
 		rc, err := f.Open()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Potential fix for [https://github.com/XiaomaiTX/AmiyaEden/security/code-scanning/35](https://github.com/XiaomaiTX/AmiyaEden/security/code-scanning/35)

General approach: When extracting from archives, treat any file names originating from the archive as untrusted. Before using them in `os.Open`, `os.Create`, or passing them recursively, normalize and validate them: reject names containing `..`, absolute paths, or path separators, and ensure that any constructed `outPath` stays within a known destination directory (`destDir`). This prevents directory traversal (Zip Slip) and ensures subsequent uses of the paths are safe.

Best concrete fix here:

1. Add a small helper, e.g. `safeJoin(destDir, name string) (string, error)`, that:
   - Rejects empty names.
   - Uses `filepath.Base` to discard any directory components.
   - Joins with `destDir`.
   - Optionally normalizes and checks that the resulting path starts with the cleaned `destDir` to guard against oddities.
2. In `extractZip`, instead of directly doing `filepath.Join(destDir, filepath.Base(f.Name))`, call `safeJoin(destDir, f.Name)` and handle errors by skipping the entry or returning an error.
3. In `extractGzip`, validate `outName` that comes from `gr.Header.Name` similarly with `safeJoin`. Note that even though we currently wrap it with `filepath.Base`, routing all archive-derived names through the same sanitization function is clearer and addresses the taint warnings.
4. `extractBzip2` gets its output name from `filepath.Base(srcPath)`, where `srcPath` may itself come from a previous extraction. Once upstream archive names are validated and we ensure all derived paths stay under `destDir`, bzip2-derived paths will also be safe. We do not need to change bzip2 logic beyond possibly using `safeJoin` for consistency, but to minimize code changes, we rely on sanitized inputs.
5. Ensure that `extractSQL` and all recursive calls always pass the same trusted `destDir` so any derived `outPath` stays within `tmp/sde`.

Specific lines to change in `server/internal/service/sde.go`:

- Around line 297 (`extractGzip`): replace the computation of `outPath` to use `safeJoin(destDir, outName)` and handle an error if the name is unsafe.
- Around line 357 (`extractZip`): replace the computation of `outPath` to use `safeJoin(destDir, f.Name)` and skip or fail on invalid entries.
- Add a new helper function `safeJoin` above `extractGzip` or near the other helpers. It will use only standard library functions (`filepath`, `strings`) which are already imported, so no new imports are needed.

This keeps existing behavior (writing extracted files under `destDir` and recursing) while adding validation that addresses all flagged flows, including subsequent uses of `sqlPath` and `srcPath` in `os.Open`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
