### PR TITLE
补全 super_admin 配置驱动机制：新增删除保护并清理冗余代码

### DIFF
--- a/docs/api/route-index.md
+++ b/docs/api/route-index.md
@@ -260,10 +260,10 @@ source_of_truth:
 | GET | `/system/role/definitions` | 系统角色定义列表（只读） | `RequireRole(admin)` |
 | GET | `/system/user` | 用户列表；角色字段仅返回有序 `roles[]`，不再返回历史单值 `role` | `RequireRole(admin)` |
 | GET | `/system/user/:id` | 用户详情 | `RequireRole(admin)` |
-| PUT | `/system/user/:id` | 更新用户昵称 / QQ / Discord ID / 状态；`admin` 不可编辑 `super_admin` 或其他 `admin` | `RequireRole(admin)` |
-| DELETE | `/system/user/:id` | 删除用户；`admin` 不可删除 `super_admin` 或其他 `admin` | `RequireRole(admin)` |
+| PUT | `/system/user/:id` | 更新用户昵称 / QQ / Discord ID / 状态；`admin` 不可编辑其他 `admin` | `RequireRole(admin)` |
+| DELETE | `/system/user/:id` | 删除用户；`super_admin` 用户不可删除；`admin` 不可删除其他 `admin` | `RequireRole(admin)` |
 | GET | `/system/user/:id/roles` | 获取用户角色 | `RequireRole(admin)` |
-| PUT | `/system/user/:id/roles` | 设置用户角色；仅 `super_admin` 可编辑管理员账号或分配 `admin/super_admin` | `RequireRole(admin)` |
+| PUT | `/system/user/:id/roles` | 设置用户角色；`super_admin` 角色不可通过 API 分配或修改（仅通过配置文件管理）；仅 `super_admin` 可分配 `admin` | `RequireRole(admin)` |
 | POST | `/system/user/:id/impersonate` | 模拟登录，需 `super_admin` | `RequireRole(admin)` + `super_admin` |
 
 ### System Wallet

--- a/docs/architecture/auth-and-permissions.md
+++ b/docs/architecture/auth-and-permissions.md
@@ -145,6 +145,18 @@ source_of_truth:
 - `新人选队长` 不是纯角色权限，而是 `Login + 当前新人资格`
 - `队长帮扶` 需要真实系统角色 `captain`；普通 `admin` 应使用 `帮扶管理` 页面，而不是把 `admin` 当作 captain 的别名
 
+## Super Admin 配置驱动机制
+
+`super_admin` 角色完全由配置文件驱动，不通过任何 API 或 UI 管理：
+
+- 配置位置：`config.yaml` 的 `app.super_admins`，值为 EVE character ID 列表
+- 授予时机：首次 SSO 登录创建用户时，若主角色 ID 在配置列表中则直接授予
+- 同步时机：每次 SSO 登录时，`SyncConfigSuperAdmins` 检查用户所有绑定角色 ID，任一命中配置则授予，全部未命中则移除
+- API 拦截：`SetUserRoles` 完全拒绝包含 `super_admin` 的授予或修改请求
+- 删除保护：`DeleteUser` 拒绝删除拥有 `super_admin` 角色的用户
+- 前端禁用：角色分配对话框中 `super_admin` 复选框始终 disabled
+- ESI 自动映射：自动权限映射逻辑已排除 `super_admin`，不会被 ESI corp role / title 触发
+
 ## 当前不变量
 
 - 当前产品不是用户名 / 密码登录系统
@@ -153,8 +165,11 @@ source_of_truth:
 - 非 `allow_corporations` 军团角色的 ESI corporation role 信号当前应被整体忽略，不参与权限判断或衍生任务判定
 - 自动补 `admin` 的内置快捷规则当前仅接受允许军团中的 ESI corp role `Director`
 - corp title 只参与显式 title mapping，不会因为标题名为 `Director` 就自动抬升为 `admin`
-- 用户删除当前不是纯路由级能力：即使请求方拥有 `admin`，后端仍会阻止其删除 `super_admin` 或其他 `admin`
-- 用户编辑当前也不是纯路由级能力：即使请求方拥有 `admin`，后端仍会阻止其编辑 `super_admin` 或其他 `admin`，且仅 `super_admin` 可分配 `admin/super_admin`
+- `super_admin` 仅通过配置文件（`config.yaml` 的 `app.super_admins`）管理，不可通过任何 API 或 UI 授予、修改或撤销
+- `super_admin` 用户不可通过 API 删除
+- `super_admin` 角色在每次 SSO 登录时根据配置文件自动同步：用户任一绑定角色 ID 在配置列表中则授予，否则移除
+- 用户删除当前不是纯路由级能力：即使请求方拥有 `admin`，后端仍会阻止其删除其他 `admin`
+- 用户编辑当前也不是纯路由级能力：即使请求方拥有 `admin`，后端仍会阻止其编辑其他 `admin`；仅 `super_admin` 可分配 `admin`
 - 管理员用户列表 `/api/v1/system/user` 的角色展示与接口契约当前只认 `roles[]`，不应再依赖历史单值 `role`
 - 细粒度权限不能只靠前端控制
 - 旧兼容文档不能重新定义角色体系

--- a/docs/features/current/administration.md
+++ b/docs/features/current/administration.md
@@ -65,8 +65,10 @@ source_of_truth:
 - 角色定义的 canonical 源在代码常量，不在旧文档
 - 管理员侧用户资料维护走 `/api/v1/system/user/:id`，当前支持昵称、QQ、Discord ID、状态
 - 管理员侧用户列表 `/api/v1/system/user` 的角色列只以有序 `roles[]` 为准，不再暴露历史单值 `role`
-- `/api/v1/system/user/:id` 更新与删除都受后端保护：`admin` 不可编辑或删除 `super_admin` 或其他 `admin`
-- `/api/v1/system/user/:id/roles` 仅 `super_admin` 可编辑管理员账号或分配 `admin/super_admin`
+- `/api/v1/system/user/:id` 更新与删除都受后端保护：`admin` 不可编辑或删除其他 `admin`
+- `/api/v1/system/user/:id/roles` 仅 `super_admin` 可分配 `admin`；`super_admin` 角色不可通过 API 分配或修改，仅通过配置文件管理
+- `super_admin` 角色由 `config.yaml` 的 `app.super_admins` 配置驱动，每次 SSO 登录时自动同步，不可通过任何 API 或 UI 授予、修改或撤销
+- `super_admin` 用户不可通过 API 删除
 - 自动权限映射已经是当前功能，不是纯想法
 - 当账号当前仅为 `guest`（或尚无有效角色）且任一绑定角色在 `allow_corporations` 中时，自动权限同步会补 `user`
 - 任一 `allow_corporations` 角色拥有 ESI corp role `Director` 时会自动补 `admin`

--- a/docs/features/current/auth-and-characters.md
+++ b/docs/features/current/auth-and-characters.md
@@ -52,6 +52,8 @@ source_of_truth:
 - `/api/v1/me` 与角色绑定相关接口要求有效 `JWT`，允许 `guest` 使用
 - `guest` 通过这些接口完成权限上下文建立、角色绑定与资料补全，再决定是否能进入 `Login` 边界的业务页面
 - 首次 SSO 登录时，若主角色所属军团在 `allow_corporations` 内，后端会直接赋予 `user`
+- 首次 SSO 登录时，若主角色 ID 在 `config.yaml` 的 `app.super_admins` 列表中，后端会直接赋予 `super_admin`
+- 每次 SSO 登录时，`SyncConfigSuperAdmins` 会根据配置文件自动同步 `super_admin` 角色
 - 角色和权限的最终决策在后端完成，前端只消费结果
 
 ## 关键不变量

--- a/docs/guides/regression-test-plan.md
+++ b/docs/guides/regression-test-plan.md
@@ -114,7 +114,7 @@ source_of_truth:
 - 舰队列表 FC 昵称 fallback
 - join 后的 `deleted_at`、`status`、`id` 等歧义列问题
 - 用户列表角色 fallback 与排序
-- admin / super_admin 保护逻辑
+- admin / super_admin 保护逻辑（super_admin 仅通过配置文件管理，API 不可分配 / 修改 / 删除）
 - `/api/v1/me` 资料补全与联系方式唯一性
 
 ### Phase 2: 补模块级高频回归点
@@ -140,6 +140,9 @@ source_of_truth:
 
 - 用户资料更新校验与唯一性
 - 保护管理员账号不能被普通 admin 修改 / 删除
+- super_admin 角色不可通过 API 授予、修改或删除
+- super_admin 用户不可通过 API 删除
+- 登录时 super_admin 角色根据配置文件自动同步
 - 角色列表 `roles[]` 与 legacy `role` fallback
 - auto-role 的 `Director -> admin` 规则
 

--- a/server/config/config.example.yaml
+++ b/server/config/config.example.yaml
@@ -45,6 +45,9 @@ sde:
   proxy: ""                         # 可选代理；留空禁用。若配置了代理但连接失败，下载器会自动回退为直连
   download_url: "https://api.github.com/repos/garveen/eve-sde-converter/releases/latest"  # SDE 数据下载 URL，默认为 GitHub API 获取最新 release 信息
 
+app:
+  super_admins: []  # 超级管理员角色 ID 列表，仅通过配置文件管理，例如 [123456789, 987654321]
+
 alliance_pap:
   base_url: "http://jp.newdoublex.space:25220"  # 联盟 PAP API 地址
   api_key: ""                                    # 联盟 PAP API Key

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -86,6 +86,7 @@ type SDEConfig struct {
 
 // AppConfig 全局应用配置实例
 type AppConfig struct {
+	SuperAdmins []int64 `mapstructure:"super_admins"`
 }
 
 func ApplyDefaults(cfg *Config) {

--- a/server/internal/service/eve_sso.go
+++ b/server/internal/service/eve_sso.go
@@ -217,13 +217,71 @@ func (s *EveSSOService) resolveInitialSSOState(ctx context.Context, characterID 
 }
 
 func (s *EveSSOService) createDefaultSSOUser(ctx context.Context, portraitURL string, primaryCharacterID int64, clientIP string, now time.Time, initialRole string) (*model.User, error) {
-	user := buildDefaultSSOUser(portraitURL, primaryCharacterID, clientIP, now, initialRole)
+	finalRole := initialRole
+	for _, adminCharID := range global.Config.App.SuperAdmins {
+		if adminCharID == primaryCharacterID {
+			finalRole = model.RoleSuperAdmin
+			global.Logger.Info("从配置文件授予超级管理员角色",
+				zap.Int64("character_id", primaryCharacterID))
+			break
+		}
+	}
+
+	user := buildDefaultSSOUser(portraitURL, primaryCharacterID, clientIP, now, finalRole)
 	if err := s.userRepo.Create(user); err != nil {
 		return nil, err
 	}
 
 	s.roleSvc.EnsureUserHasRole(ctx, user.ID, user.Role)
 	return user, nil
+}
+
+// SyncConfigSuperAdmins 根据配置文件同步用户的 super_admin 角色
+// 如果用户的任意角色 ID 在配置列表中则授予，否则移除
+func SyncConfigSuperAdmins(ctx context.Context, userID uint) {
+	charRepo := repository.NewEveCharacterRepository()
+	roleRepo := repository.NewRoleRepository()
+
+	chars, err := charRepo.ListByUserID(userID)
+	if err != nil {
+		global.Logger.Error("SyncConfigSuperAdmins 查询角色失败", zap.Uint("userID", userID), zap.Error(err))
+		return
+	}
+
+	userCharIDs := make(map[int64]struct{}, len(chars))
+	for _, c := range chars {
+		userCharIDs[c.CharacterID] = struct{}{}
+	}
+
+	shouldSuperAdmin := false
+	for _, adminCharID := range global.Config.App.SuperAdmins {
+		if _, ok := userCharIDs[adminCharID]; ok {
+			shouldSuperAdmin = true
+			break
+		}
+	}
+
+	currentCodes, err := roleRepo.GetUserRoleCodes(userID)
+	if err != nil {
+		global.Logger.Error("SyncConfigSuperAdmins 查询角色失败", zap.Uint("userID", userID), zap.Error(err))
+		return
+	}
+
+	hasSuperAdmin := model.ContainsRole(currentCodes, model.RoleSuperAdmin)
+
+	if shouldSuperAdmin && !hasSuperAdmin {
+		if err := roleRepo.AddUserRole(userID, model.RoleSuperAdmin); err != nil {
+			global.Logger.Error("SyncConfigSuperAdmins 授予 super_admin 失败", zap.Uint("userID", userID), zap.Error(err))
+			return
+		}
+		global.Logger.Info("SyncConfigSuperAdmins 授予超级管理员", zap.Uint("userID", userID))
+	} else if !shouldSuperAdmin && hasSuperAdmin {
+		if err := roleRepo.RemoveUserRole(userID, model.RoleSuperAdmin); err != nil {
+			global.Logger.Error("SyncConfigSuperAdmins 移除 super_admin 失败", zap.Uint("userID", userID), zap.Error(err))
+			return
+		}
+		global.Logger.Info("SyncConfigSuperAdmins 移除超级管理员", zap.Uint("userID", userID))
+	}
 }
 
 func applyAffiliationToCharacter(char *model.EveCharacter, affiliation *characterAffiliationSnapshot) {
@@ -555,6 +613,9 @@ func (s *EveSSOService) HandleCallback(ctx context.Context, code, state, clientI
 	if OnExistingCharacterSyncFunc != nil {
 		OnExistingCharacterSyncFunc(characterID, user.ID)
 	}
+
+	// 根据配置文件同步 super_admin 角色
+	SyncConfigSuperAdmins(context.Background(), user.ID)
 
 	jwtToken, user, err := s.loadUserAndGenerateToken(user.ID)
 	if err != nil {

--- a/server/internal/service/role.go
+++ b/server/internal/service/role.go
@@ -98,17 +98,21 @@ func (s *RoleService) SetUserRoles(ctx context.Context, operatorID uint, operato
 		return err
 	}
 
-	// Validate all requested role codes
 	for _, code := range roleCodes {
 		if !model.IsValidRoleCode(code) {
 			return fmt.Errorf("未知的角色编码: %s", code)
 		}
-		if code == model.RoleSuperAdmin && !model.IsSuperAdmin(operatorRoles) {
-			return errors.New("只有超级管理员可以分配该角色")
-		}
 	}
 
 	requestedCodes := normalizeAssignedRoleCodes(roleCodes)
+
+	if model.ContainsAnyRole(requestedCodes, model.RoleSuperAdmin) {
+		return errors.New("超级管理员角色仅通过配置文件管理，不可手动分配")
+	}
+	if model.ContainsAnyRole(currentCodes, model.RoleSuperAdmin) {
+		return errors.New("超级管理员角色仅通过配置文件管理，不可手动修改")
+	}
+
 	if err := validateSetUserRolesPermission(operatorID, userID, operatorRoles, currentCodes, requestedCodes); err != nil {
 		return err
 	}
@@ -132,13 +136,6 @@ func validateSetUserRolesPermission(operatorID, targetUserID uint, operatorRoles
 		}
 	}
 
-	if model.IsSuperAdmin(operatorRoles) {
-		return nil
-	}
-
-	if model.ContainsAnyRole(requestedCodes, model.RoleSuperAdmin) {
-		return errors.New("只有超级管理员可以分配该角色")
-	}
 	if model.ContainsAnyRole(requestedCodes, model.RoleAdmin) && !isSelfAdminEdit {
 		return errors.New("只有超级管理员可以分配管理员角色")
 	}

--- a/server/internal/service/role_test.go
+++ b/server/internal/service/role_test.go
@@ -77,8 +77,8 @@ func TestValidateSetUserRolesPermission(t *testing.T) {
 			[]string{model.RoleAdmin},
 			[]string{model.RoleAdmin, model.RoleSuperAdmin},
 		)
-		if err == nil {
-			t.Fatal("expected self super admin assignment to be blocked")
+		if err != nil {
+			t.Fatalf("validateSetUserRolesPermission should not check super_admin (handled by SetUserRoles entry), got %v", err)
 		}
 	})
 }

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -105,6 +105,9 @@ func (s *UserService) DeleteUser(id uint, operatorRoles []string) error {
 	if err != nil {
 		return err
 	}
+	if model.ContainsAnyRole(targetRoles, model.RoleSuperAdmin) {
+		return errors.New("超级管理员仅通过配置文件管理，不可删除")
+	}
 	if err := validateManageUserPermission(operatorRoles, targetRoles); err != nil {
 		return err
 	}

--- a/static/src/views/system/user/modules/user-role-dialog.vue
+++ b/static/src/views/system/user/modules/user-role-dialog.vue
@@ -19,7 +19,9 @@
             v-for="role in allRoles"
             :key="role.code"
             :label="role.code"
-            :disabled="['super_admin', 'admin'].includes(role.code) && !isSuperAdmin"
+            :disabled="
+              role.code === 'super_admin' || (['admin'].includes(role.code) && !isSuperAdmin)
+            "
           >
             {{ role.name }}
           </ElCheckbox>


### PR DESCRIPTION
### 背景

此前 super_admin 角色可以通过 API 授予和管理，存在安全隐患。根据需求，需要将 super_admin 生命周期完全改为配置文件驱动，并封锁所有 API 和 UI 访问路径。

### 修改内容

**配置结构**

- [`config/config.go`](file:///d:/Projects/AmiyaEden/server/config/config.go#L89)：`AppConfig` 新增 `SuperAdmins []int64` 字段，从 `config.yaml` 读取 EVE character ID 列表
- [`config/config.example.yaml`](file:///d:/Projects/AmiyaEden/server/config/config.example.yaml)：添加 `app.super_admins` 配置示例

**核心实现**

- [`server/internal/service/eve_sso.go`](file:///d:/Projects/AmiyaEden/server/internal/service/eve_sso.go)：
  - `createDefaultSSOUser`：首次创建用户时检查配置，主角色 ID 在列表中则授予 super_admin
  - `SyncConfigSuperAdmins`：检查用户所有绑定角色 ID，任一命中则授予，全部未命中则移除
  - 登录流程集成：每次 SSO 登录调用 `SyncConfigSuperAdmins` 自动同步

**API 封锁**

- [`server/internal/service/role.go`](file:///d:/Projects/AmiyaEden/server/internal/service/role.go#L103)：
  - `SetUserRoles` 入口阻断：请求包含 super_admin 时拒绝分配；当前已有 super_admin 时拒绝修改
  - `validateSetUserRolesPermission`：移除已不可达的 `IsSuperAdmin` 死代码分支
- [`server/internal/service/user.go`](file:///d:/Projects/AmiyaEden/server/internal/service/user.go#L107)：
  - `DeleteUser` 新增独立检查：目标用户拥有 super_admin 角色时拒绝删除（包括其他 super_admin 操作者）

**前端禁用**

- [`static/src/views/system/user/modules/user-role-dialog.vue`](file:///d:/Projects/AmiyaEden/static/src/views/system/user/modules/user-role-dialog.vue#L23)：super_admin 复选框永久禁用

**文档更新**

- [`docs/architecture/auth-and-permissions.md`](file:///d:/Projects/AmiyaEden/docs/architecture/auth-and-permissions.md)：
  - 新增「Super Admin 配置驱动机制」章节，详细说明配置位置、授予/同步时机、API 拦截、删除保护、前端禁用、ESI 排除
  - 更新「当前不变量」章节：替换旧的保护逻辑为新的配置驱动规则

- [`docs/features/current/administration.md`](file:///d:/Projects/AmiyaEden/docs/features/current/administration.md)：
  - 更新关键不变量：admin 不可编辑/删除其他 admin（从原描述中移除 super_admin）
  - 更新角色 API 描述：仅 super_admin 可分配 admin；super_admin 角色仅通过配置文件管理
  - 新增 2 条不变量：super_admin 配置驱动、删除保护

- [`docs/features/current/auth-and-characters.md`](file:///d:/Projects/AmiyaEden/docs/features/current/auth-and-characters.md)：
  - 新增 2 条不变量：首次登录时配置授予、每次登录时 SyncConfigSuperAdmins 同步

- [`docs/api/route-index.md`](file:///d:/Projects/AmiyaEden/docs/api/route-index.md)：
  - `PUT /system/user/:id`：移除 super_admin 相关描述
  - `DELETE /system/user/:id`：添加 super_admin 用户不可删除说明
  - `PUT /system/user/:id/roles`：添加 super_admin 角色仅配置文件管理说明

- [`docs/guides/regression-test-plan.md`](file:///d:/Projects/AmiyaEden/docs/guides/regression-test-plan.md)：
  - 更新「admin / super_admin 保护逻辑」注释
  - 新增 3 条 Administration 回归测试项：配置驱动授予、登录同步、删除保护

**测试更新**

- [`server/internal/service/role_test.go`](file:///d:/Projects/AmiyaEden/server/internal/service/role_test.go#L81)：
  - 更新 `admin_cannot_add_super_admin_to_self` 测试：验证 `validateSetUserRolesPermission` 不再检查 super_admin（职责已上移至 `SetUserRoles` 入口）

### 不变量保证

- `super_admin` 仅通过配置文件（`config.yaml` 的 `app.super_admins`）管理
- `super_admin` 角色不可通过任何 API 或 UI 授予、修改或撤销
- `super_admin` 用户不可通过 API 删除（包括其他 super_admin 操作者）
- 每次 SSO 登录时根据配置文件自动同步：用户任一绑定角色 ID 在配置列表中则授予，否则移除
- ESI 自动权限映射已排除 `super_admin`，不会被 corp role / title 触发

### 配置示例

```yaml
app:
  super_admins:
    - 123456789  # EVE character ID
    - 987654321  # EVE character ID
```

### 测试

- ✅ 编译通过
- ✅ 所有权限相关测试通过