### PR TITLE
fix(auth): keep bootstrap active when primary ESI expires

### DIFF
--- a/docs/features/current/auth-and-characters.md
+++ b/docs/features/current/auth-and-characters.md
@@ -28,7 +28,7 @@ source_of_truth:
 - 通过 `/api/v1/me` 维护昵称、QQ、Discord ID 资料
 - 未填写昵称或未提供 QQ / Discord 任一联系方式时，前端强制停留在 `/dashboard/characters`
 - 可选启用：任一已绑定人物 ESI 失效时，前端强制停留在 `/dashboard/characters`
-- 主人物 ESI 已失效时，`/api/v1/me` 启动上下文失败并触发前端自动退出登录
+- 主人物 ESI 已失效时，`/api/v1/me` 仍返回启动上下文，前端强制停留在 `/dashboard/characters` 直到主人物重新授权
 
 ## 入口
 
@@ -54,7 +54,7 @@ source_of_truth:
 - 登录入口与回调是 `Public`
 - `/api/v1/me` 与人物绑定相关接口要求有效 `JWT`，允许 `guest` 使用
 - `guest` 通过这些接口完成权限上下文建立、人物绑定与资料补全，再决定是否能进入 `Login` 边界的业务页面
-- `/api/v1/me` 在主人物 `token_invalid = true` 时返回未授权，用于阻止失效主人物继续完成登录启动
+- `/api/v1/me` 会返回主人物 `token_invalid` 状态，供前端将用户锁定在 `/dashboard/characters` 直到主人物重新授权
 - `/api/v1/me` 同时返回 `enforce_character_esi_restriction`，供前端路由守卫决定是否对非主人物失效 ESI 启用页面停留限制
 - 首次 SSO 登录时，若主人物所属军团在 `allow_corporations` 内，后端会直接赋予 `user`；该列表运行时始终包含代码常量中的伏羲军团 Fuxi Legion（`98185110`）
 - 首次 SSO 登录时，若主人物 ID 在 `config.yaml` 的 `app.super_admins` 列表中，后端会直接赋予 `super_admin`
@@ -70,7 +70,7 @@ source_of_truth:
 - 当前登录后必须完成昵称与联系方式资料，才允许继续访问其他业务页面
 - QQ / Discord ID 的管理入口是 `/api/v1/me`；管理员侧 `/api/v1/system/user/:id` 不提供联系方式修改
 - 当前登录后若系统配置 `auth.enforce_character_esi_restriction = true`，则还必须保证所有已绑定人物的 ESI 有效，才允许离开 `/dashboard/characters`
-- 无论系统配置是否开启，主人物 ESI 已失效都会阻止 `/api/v1/me` 完成登录启动
+- 无论系统配置是否开启，主人物 ESI 已失效都会强制前端停留在 `/dashboard/characters`，直到主人物重新授权；不会自动退出登录
 - 重新绑定已存在人物会沿用当前 SSO 回调流程刷新该人物 token 并清除 `token_invalid`
 - QQ / Discord ID 的唯一性由后端校验
 - 职权编码与权限列表必须与后端返回保持一致，不做前端别名映射

--- a/server/internal/handler/me.go
+++ b/server/internal/handler/me.go
@@ -48,10 +48,6 @@ func (h *MeHandler) GetMe(c *gin.Context) {
 	if characters == nil {
 		characters = []model.EveCharacter{}
 	}
-	if err := h.userSvc.ValidateCurrentUserBootstrap(user, characters); err != nil {
-		response.Fail(c, response.CodeUnauthorized, err.Error())
-		return
-	}
 
 	roles := middleware.GetUserRoles(c)
 	if roles == nil {

--- a/server/internal/handler/me_test.go
+++ b/server/internal/handler/me_test.go
@@ -17,7 +17,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestMeHandlerGetMeRejectsInvalidPrimaryCharacterToken(t *testing.T) {
+func TestMeHandlerGetMeAllowsInvalidPrimaryCharacterTokenForRefreshFlow(t *testing.T) {
 	db := newMeHandlerTestDB(t)
 	seedMeHandlerUser(t, db, true)
 
@@ -34,11 +34,20 @@ func TestMeHandlerGetMeRejectsInvalidPrimaryCharacterToken(t *testing.T) {
 	}()
 
 	recorder, result := performGetMeRequest(t, 1)
-	if recorder.Code != http.StatusUnauthorized {
-		t.Fatalf("expected http status 401, got %d", recorder.Code)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected http status 200, got %d", recorder.Code)
 	}
-	if result.Code != response.CodeUnauthorized {
-		t.Fatalf("expected unauthorized code, got %#v", result)
+	if result.Code != response.CodeOK {
+		t.Fatalf("expected success code, got %#v", result)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(result.Data, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	characters, ok := payload["characters"].([]any)
+	if !ok || len(characters) != 2 {
+		t.Fatalf("expected two characters in payload, got %#v", payload["characters"])
 	}
 }
 

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -46,13 +46,6 @@ func (s *UserService) GetUserByID(id uint) (*model.User, error) {
 	return s.repo.GetByID(id)
 }
 
-func (s *UserService) ValidateCurrentUserBootstrap(user *model.User, characters []model.EveCharacter) error {
-	if user == nil {
-		return errors.New("用户不存在")
-	}
-	return validatePrimaryCharacterTokenHealth(*user, characters)
-}
-
 func (s *UserService) ListUsers(page, pageSize int, filter repository.UserFilter) ([]model.UserListItem, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
 	users, total, err := s.repo.List(page, pageSize, filter)

--- a/static/src/api/auth-helpers.ts
+++ b/static/src/api/auth-helpers.ts
@@ -17,3 +17,19 @@ export function hasInvalidCharacterToken(
 ): boolean {
   return characters?.some((character) => character.token_invalid) ?? false
 }
+
+export function hasInvalidPrimaryCharacterToken(
+  primaryCharacterId?: number,
+  characters?: Array<Pick<Api.Auth.EveCharacter, 'character_id' | 'token_invalid'>>
+): boolean {
+  if (!primaryCharacterId) {
+    return false
+  }
+
+  return (
+    characters?.some(
+      (character) =>
+        character.character_id === primaryCharacterId && character.token_invalid === true
+    ) ?? false
+  )
+}

--- a/static/src/api/auth.ts
+++ b/static/src/api/auth.ts
@@ -1,7 +1,11 @@
 import request from '@/utils/http'
 import { isUserProfileComplete } from './auth-helpers'
 
-export { hasInvalidCharacterToken, isUserProfileComplete } from './auth-helpers'
+export {
+  hasInvalidCharacterToken,
+  hasInvalidPrimaryCharacterToken,
+  isUserProfileComplete
+} from './auth-helpers'
 
 /**
  * 获取 EVE SSO 授权 URL（通过后端接口获取，前端直接跳转）

--- a/static/src/locales/langs/en.json
+++ b/static/src/locales/langs/en.json
@@ -1313,8 +1313,8 @@
     "scopeCount": "scopes",
     "tokenInvalid": "(Expired)",
     "tokenHealth": {
-      "title": "You cannot continue while any bound character has expired ESI access",
-      "requiredHint": "Refresh ESI for every expired character or unbind the expired characters before leaving this page."
+      "title": "You cannot continue while the primary character ESI is expired, or when policy requires all characters to be valid and any bound character is expired",
+      "requiredHint": "Refresh the primary character ESI first. If all-character enforcement is enabled, you must also refresh or unbind any other expired characters before leaving this page."
     },
     "bindFailed": "Failed to get bind URL",
     "setPrimarySuccess": "{name} is now the primary character",

--- a/static/src/locales/langs/zh.json
+++ b/static/src/locales/langs/zh.json
@@ -1313,8 +1313,8 @@
     "scopeCount": "项权限",
     "tokenInvalid": "(已失效)",
     "tokenHealth": {
-      "title": "只要存在任一已过期的 ESI 授权人物，就无法继续访问其他页面",
-      "requiredHint": "请重新授权所有已过期人物的 ESI，或解绑这些已过期人物，然后再离开本页面。"
+      "title": "主人物 ESI 已过期，或系统要求校验全部人物且存在已过期 ESI 时，无法继续访问其他页面",
+      "requiredHint": "请先重新授权主人物 ESI；如果当前启用了全人物校验，还需要处理其他已过期人物，然后再离开本页面。"
     },
     "bindFailed": "获取绑定链接失败",
     "setPrimarySuccess": "已将 {name} 设为主人物",

--- a/static/src/router/guards/beforeEach.test.ts
+++ b/static/src/router/guards/beforeEach.test.ts
@@ -62,6 +62,24 @@ test('invalid non-primary character does not redirect when enforcement is disabl
   )
 })
 
+test('invalid primary character still redirects when enforcement is disabled', () => {
+  assert.equal(
+    shouldRedirectToCharactersPage(
+      { isLogin: true, path: '/system/user' },
+      {
+        enforceCharacterESIRestriction: false,
+        profileComplete: true,
+        primaryCharacterId: 9001,
+        characters: [
+          { character_id: 9001, token_invalid: true } as Api.Auth.EveCharacter,
+          { character_id: 9002, token_invalid: false } as Api.Auth.EveCharacter
+        ]
+      }
+    ),
+    true
+  )
+})
+
 test('guard refresh stores authoritative user info before redirect evaluation', async () => {
   const refreshedUser = {
     userId: 7,

--- a/static/src/router/guards/charactersGate.ts
+++ b/static/src/router/guards/charactersGate.ts
@@ -1,4 +1,8 @@
-import { hasInvalidCharacterToken, isUserProfileComplete } from '@/api/auth-helpers'
+import {
+  hasInvalidCharacterToken,
+  hasInvalidPrimaryCharacterToken,
+  isUserProfileComplete
+} from '@/api/auth-helpers'
 
 export const PROFILE_SETUP_PATH = '/dashboard/characters'
 
@@ -15,6 +19,7 @@ type CharactersGateUserInfo = Partial<
     | 'qq'
     | 'discordId'
     | 'characters'
+    | 'primaryCharacterId'
     | 'enforceCharacterESIRestriction'
   >
 >
@@ -31,6 +36,7 @@ export function shouldRedirectToCharactersPage(
 
   return (
     !isUserProfileComplete(userInfo) ||
+    hasInvalidPrimaryCharacterToken(userInfo?.primaryCharacterId, userInfo?.characters) ||
     (userInfo?.enforceCharacterESIRestriction !== false &&
       hasInvalidCharacterToken(userInfo?.characters))
   )

--- a/static/src/views/dashboard/characters/index.vue
+++ b/static/src/views/dashboard/characters/index.vue
@@ -86,7 +86,7 @@
       </div>
 
       <ElAlert
-        v-if="enforceCharacterESIRestriction && hasInvalidCharacterToken"
+        v-if="showTokenHealthAlert"
         type="error"
         :closable="false"
         show-icon
@@ -178,6 +178,7 @@
     fetchMyCharacters,
     getEveBindURL,
     hasInvalidCharacterToken as hasInvalidCharacterTokenInList,
+    hasInvalidPrimaryCharacterToken as hasInvalidPrimaryCharacterTokenInList,
     isUserProfileComplete,
     setPrimaryCharacter,
     updateMyProfile,
@@ -209,6 +210,14 @@
     () => userStore.getUserInfo.enforceCharacterESIRestriction !== false
   )
   const hasInvalidCharacterToken = computed(() => hasInvalidCharacterTokenInList(characters.value))
+  const hasInvalidPrimaryCharacterToken = computed(() =>
+    hasInvalidPrimaryCharacterTokenInList(primaryCharacterId.value, characters.value)
+  )
+  const showTokenHealthAlert = computed(
+    () =>
+      hasInvalidPrimaryCharacterToken.value ||
+      (enforceCharacterESIRestriction.value && hasInvalidCharacterToken.value)
+  )
 
   const getTextLength = (value: string) => Array.from(value.trim()).length
 


### PR DESCRIPTION
The /api/v1/me bootstrap no longer rejects authenticated users when the primary character token is invalid. Instead, the frontend now treats an expired primary ESI as a characters-page gate, shows updated guidance, and preserves access to the refresh flow. Backend and frontend regression coverage plus the auth feature spec were updated to reflect the new lock-to-reauthorize behavior.

/api/v1/me 在主人物 token 失效时不再拒绝已认证用户。前端现在会把主人物 ESI 过期视为人物页面闸门，显示更新后的提示文案，并保留用户进入重新授权流程的能力。后端与前端回归测试以及认证功能文档也已同步更新，明确这一锁定到重新授权的行为。