### PR TITLE
fix(release): ship 1.8.0 service and localization cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-05-16
+
+### Added
+- 新增用户、工单、工具收藏与 Fuxi Hall 的审计覆盖。
+
+### Changed
+- Fuxi Hall 成员头衔展示改为使用头衔标签，并同步相关契约、页面与文档。
+- 更新 static-react 依赖锁定版本。
+
+### Fixed
+- 将我的福利页技能规划检查链接改为本地化文案。
+- 将注册页、信息页钱包与技能 ESI 刷新提示改为本地化文案。
+- 将富文本编辑器默认占位符与图片上传提示改为本地化文案。
+- 将联盟 PAP SEAT 导入请求移入前端 API 层，避免页面模块直接创建 HTTP 请求。
+- 将基础配置页 SDE 时间展示改为复用共享时间格式化工具。
+- 移除系统用户处理器对 repository 筛选类型的直接依赖。
+- 移除系统钱包处理器对 repository 筛选类型的直接依赖。
+- 移除审计日志处理器对 repository 筛选类型的直接依赖。
+- 将 SRP 配置读写收敛到服务层，处理器不再直接访问系统配置仓储。
+- 移除 SRP 处理器对 repository 申请筛选类型的直接依赖。
+- 移除工单处理器对 repository 筛选类型的直接依赖。
+- 移除舰队、商店与福利处理器对 repository 筛选类型的直接依赖。
+- 将系统配置读写、个人资料人物查询、联盟 PAP 主人物解析与 ESI 刷新人物查询收敛到服务层。
+- 移除 SDE 处理器对 repository 名称映射类型的直接依赖。
+- 将自动权限、舰队与 SDE 服务的公开返回类型改为服务层契约，避免 repository DTO 向处理器层泄漏。
+- 将共享业务组件的通知、SDE 搜索与 KM 详情请求改为经由 hooks 调用，避免组件直接依赖 API 层。
+- 将 SRP 管理 hook 的表格按钮组件依赖上移到页面注入，避免 hooks 直接依赖组件层。
+- 移除通知面板中的硬编码中文回退文案，补齐对应中英文通知本地化文本。
+- 将路由权限动作标题改为本地化键，并补齐对应中英文文案与回归测试。
+- 将系统个人中心页面与 Webhook 服务商选项改为本地化文案，并补齐回归测试。
+- 将系统钱包日志列、SRP 导出列、导出工作表名与默认审批备注改为本地化文案。
+- 将共享表格空状态、Excel 导出默认文案与代码块复制提示改为本地化文案。
+- 将表格加载、存储恢复、颜色校验与动态菜单失败提示改为本地化文案。
+
 ## [1.7.0] - 2026-05-13
 
 ### Added

--- a/server/internal/handler/alliance_pap.go
+++ b/server/internal/handler/alliance_pap.go
@@ -4,7 +4,6 @@ import (
 	"amiya-eden/global"
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/internal/utils"
 	"amiya-eden/pkg/response"
@@ -16,16 +15,12 @@ import (
 
 // AlliancePAPHandler 联盟 PAP HTTP 处理器
 type AlliancePAPHandler struct {
-	svc      *service.AlliancePAPService
-	charRepo *repository.EveCharacterRepository
-	userRepo *repository.UserRepository
+	svc *service.AlliancePAPService
 }
 
 func NewAlliancePAPHandler() *AlliancePAPHandler {
 	return &AlliancePAPHandler{
-		svc:      service.NewAlliancePAPService(),
-		charRepo: repository.NewEveCharacterRepository(),
-		userRepo: repository.NewUserRepository(),
+		svc: service.NewAlliancePAPService(),
 	}
 }
 
@@ -58,19 +53,7 @@ func (h *AlliancePAPHandler) GetMyAlliancePAP(c *gin.Context) {
 	}
 
 	userID := middleware.GetUserID(c)
-	user, err := h.userRepo.GetByID(userID)
-	if err != nil || user.PrimaryCharacterID == 0 {
-		response.Fail(c, response.CodeBizError, "未设置主人物")
-		return
-	}
-
-	char, err := h.charRepo.GetByCharacterID(user.PrimaryCharacterID)
-	if err != nil {
-		response.Fail(c, response.CodeBizError, "主人物不存在")
-		return
-	}
-
-	result, err := h.svc.GetMyPAP(char.CharacterName, year, month)
+	result, err := h.svc.GetMyPAPByUserID(userID, year, month)
 	if err != nil {
 		response.Fail(c, response.CodeBizError, err.Error())
 		return
@@ -154,20 +137,7 @@ func (h *AlliancePAPHandler) ImportAlliancePAP(c *gin.Context) {
 		return
 	}
 
-	char, err := h.charRepo.GetByCharacterName(req.PAPImportInfo.PrimaryCharacterName)
-	if err != nil {
-		response.Fail(c, response.CodeBizError, "主人物不存在")
-		return
-	}
-
-	user, err := h.userRepo.GetByPrimaryCharacterID(char.CharacterID)
-	if err != nil || user.PrimaryCharacterID == 0 {
-		response.Fail(c, response.CodeBizError, "未设置主人物")
-		return
-	}
-
-	err = h.svc.ImportAlliancePAP(req.Year, req.Month, &req.PAPImportInfo, char)
-	if err != nil {
+	if err := h.svc.ImportAlliancePAPByPrimaryCharacter(req.Year, req.Month, &req.PAPImportInfo); err != nil {
 		response.Fail(c, response.CodeBizError, err.Error())
 		return
 	}

--- a/server/internal/handler/audit_event.go
+++ b/server/internal/handler/audit_event.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"amiya-eden/internal/middleware"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 	"errors"
@@ -71,23 +70,23 @@ func parseAuditDate(raw string, field string) (*time.Time, error) {
 	return &t, nil
 }
 
-func (h *AuditEventHandler) buildFilter(in adminAuditEventListRequestInner) (repository.AuditEventFilter, error) {
+func (h *AuditEventHandler) buildFilter(in adminAuditEventListRequestInner) (service.AuditEventFilter, error) {
 	start, err := parseAuditDate(in.StartDate, "start_date")
 	if err != nil {
-		return repository.AuditEventFilter{}, err
+		return service.AuditEventFilter{}, err
 	}
 	end, err := parseAuditDate(in.EndDate, "end_date")
 	if err != nil {
-		return repository.AuditEventFilter{}, err
+		return service.AuditEventFilter{}, err
 	}
 	if start != nil && end != nil && start.After(*end) {
-		return repository.AuditEventFilter{}, fmt.Errorf("start_date cannot be later than end_date")
+		return service.AuditEventFilter{}, fmt.Errorf("start_date cannot be later than end_date")
 	}
 	if end != nil {
 		next := end.Add(24*time.Hour - time.Nanosecond)
 		end = &next
 	}
-	return repository.AuditEventFilter{
+	return service.AuditEventFilter{
 		StartDate:    start,
 		EndDate:      end,
 		Category:     in.Category,

--- a/server/internal/handler/esi_refresh.go
+++ b/server/internal/handler/esi_refresh.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"amiya-eden/global"
 	"amiya-eden/internal/middleware"
-	"amiya-eden/internal/repository"
+	"amiya-eden/internal/service"
 	"amiya-eden/jobs"
 	"amiya-eden/pkg/eve/esi"
 	"amiya-eden/pkg/response"
@@ -18,10 +18,12 @@ import (
 )
 
 // ESIRefreshHandler ESI 数据刷新队列处理器
-type ESIRefreshHandler struct{}
+type ESIRefreshHandler struct {
+	userSvc *service.UserService
+}
 
 func NewESIRefreshHandler() *ESIRefreshHandler {
-	return &ESIRefreshHandler{}
+	return &ESIRefreshHandler{userSvc: service.NewUserService()}
 }
 
 // TaskInfoItem 任务定义信息（用于前端展示所有可用任务）
@@ -136,7 +138,7 @@ func (h *ESIRefreshHandler) GetStatuses(c *gin.Context) {
 	}
 
 	all := queue.GetAllStatuses()
-	characterNames := buildCharacterNameMap(all)
+	characterNames := h.buildCharacterNameMap(all)
 
 	// 筛选
 	taskNameFilter := c.Query("task_name")
@@ -215,7 +217,7 @@ func (h *ESIRefreshHandler) GetMonitor(c *gin.Context) {
 
 	now := time.Now().UTC()
 	statuses := queue.GetAllStatuses()
-	characterNames := buildCharacterNameMap(statuses)
+	characterNames := h.buildCharacterNameMap(statuses)
 
 	panelByTask := make(map[string]*MonitorTaskPanelItem)
 	failureTop := make([]MonitorFailureItem, 0, len(statuses))
@@ -400,8 +402,7 @@ func (h *ESIRefreshHandler) RunMyCharacterTask(c *gin.Context) {
 		return
 	}
 
-	charRepo := repository.NewEveCharacterRepository()
-	char, err := charRepo.GetByCharacterID(req.CharacterID)
+	char, err := h.userSvc.GetCharacterByID(req.CharacterID)
 	if err != nil {
 		response.Fail(c, response.CodeBizError, "角色不存在")
 		return
@@ -499,9 +500,7 @@ func formatDuration(d time.Duration) string {
 	return d.String()
 }
 
-func buildCharacterNameMap(statuses []*esi.TaskStatus) map[int64]string {
-	charRepo := repository.NewEveCharacterRepository()
-	characterNames := make(map[int64]string, len(statuses))
+func (h *ESIRefreshHandler) buildCharacterNameMap(statuses []*esi.TaskStatus) map[int64]string {
 	characterIDs := make([]int64, 0, len(statuses))
 	seenCharacterIDs := make(map[int64]struct{}, len(statuses))
 	for _, status := range statuses {
@@ -514,12 +513,7 @@ func buildCharacterNameMap(statuses []*esi.TaskStatus) map[int64]string {
 		seenCharacterIDs[status.CharacterID] = struct{}{}
 		characterIDs = append(characterIDs, status.CharacterID)
 	}
-	if chars, err := charRepo.ListByCharacterIDs(characterIDs); err == nil {
-		for _, char := range chars {
-			characterNames[char.CharacterID] = char.CharacterName
-		}
-	}
-	return characterNames
+	return h.userSvc.ListCharacterNamesByIDs(characterIDs)
 }
 
 func ensureTaskPanel(panelByTask map[string]*MonitorTaskPanelItem, status *esi.TaskStatus) *MonitorTaskPanelItem {

--- a/server/internal/handler/fleet.go
+++ b/server/internal/handler/fleet.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"amiya-eden/internal/middleware"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 	"strconv"
@@ -60,7 +59,7 @@ func (h *FleetHandler) ListFleets(c *gin.Context) {
 		return
 	}
 
-	filter := repository.FleetFilter{
+	filter := service.FleetFilter{
 		Importance: c.Query("importance"),
 	}
 	if fcStr := c.Query("fc_user_id"); fcStr != "" {

--- a/server/internal/handler/me.go
+++ b/server/internal/handler/me.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 
@@ -13,8 +12,7 @@ import (
 type MeHandler struct {
 	userSvc              *service.UserService
 	roleSvc              *service.RoleService
-	charRepo             *repository.EveCharacterRepository
-	sysConfigRepo        *repository.SysConfigRepository
+	cfgSvc               *service.SysConfigService
 	eligibilitySvc       *service.NewbroEligibilityService
 	mentorEligibilitySvc *service.MentorEligibilityService
 }
@@ -23,8 +21,7 @@ func NewMeHandler() *MeHandler {
 	return &MeHandler{
 		userSvc:              service.NewUserService(),
 		roleSvc:              service.NewRoleService(),
-		charRepo:             repository.NewEveCharacterRepository(),
-		sysConfigRepo:        repository.NewSysConfigRepository(),
+		cfgSvc:               service.NewSysConfigService(),
 		eligibilitySvc:       service.NewNewbroEligibilityService(),
 		mentorEligibilitySvc: service.NewMentorEligibilityService(),
 	}
@@ -40,7 +37,7 @@ func (h *MeHandler) GetMe(c *gin.Context) {
 		return
 	}
 
-	characters, err := h.charRepo.ListByUserID(userID)
+	characters, err := h.userSvc.ListUserCharacters(userID)
 	if err != nil {
 		response.Fail(c, response.CodeBizError, "加载人物信息失败")
 		return
@@ -63,10 +60,7 @@ func (h *MeHandler) GetMe(c *gin.Context) {
 		value := result.IsEligible
 		isMentorMenteeEligible = &value
 	}
-	enforceCharacterESIRestriction := h.sysConfigRepo.GetBool(
-		model.SysConfigEnforceCharacterESIRestriction,
-		model.SysConfigDefaultEnforceCharacterESIRestriction,
-	)
+	enforceCharacterESIRestriction := h.cfgSvc.GetCharacterESIRestrictionConfig()
 
 	response.OK(c, gin.H{
 		"user":                              user,

--- a/server/internal/handler/sde.go
+++ b/server/internal/handler/sde.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/eve/esi"
 	"amiya-eden/pkg/response"
@@ -94,7 +93,7 @@ func newGetNamesResponse() GetNamesResponse {
 	}
 }
 
-func mergeGetNamesNamespaces(result *GetNamesResponse, names repository.SdeNameMap) {
+func mergeGetNamesNamespaces(result *GetNamesResponse, names service.SdeNameMap) {
 	namespaces := make([]string, 0, len(names))
 	for namespace := range names {
 		namespaces = append(namespaces, namespace)

--- a/server/internal/handler/sde_test.go
+++ b/server/internal/handler/sde_test.go
@@ -1,14 +1,14 @@
 package handler
 
 import (
-	"amiya-eden/internal/repository"
+	"amiya-eden/internal/service"
 	"testing"
 )
 
 func TestMergeGetNamesNamespacesPreservesNamespacesAndFlatFirstWins(t *testing.T) {
 	result := newGetNamesResponse()
 
-	mergeGetNamesNamespaces(&result, repository.SdeNameMap{
+	mergeGetNamesNamespaces(&result, service.SdeNameMap{
 		"type": {
 			1: "Rifter",
 			2: "Punisher",

--- a/server/internal/handler/shop.go
+++ b/server/internal/handler/shop.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 
@@ -218,7 +217,7 @@ func (h *ShopHandler) AdminListProducts(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizePagination(req.Current, req.Size, 20, 100)
 
-	filter := repository.ProductFilter{
+	filter := service.ProductFilter{
 		Status: req.Status,
 		Type:   req.Type,
 		Name:   req.Name,
@@ -251,7 +250,7 @@ func (h *ShopHandler) AdminListOrders(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizeLedgerPagination(req.Current, req.Size)
 
-	filter := repository.OrderFilter{
+	filter := service.OrderFilter{
 		Keyword:  req.Keyword,
 		Statuses: req.Statuses,
 		Status:   req.Status,

--- a/server/internal/handler/srp.go
+++ b/server/internal/handler/srp.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"amiya-eden/internal/middleware"
-	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 	"fmt"
@@ -14,14 +12,12 @@ import (
 
 // SrpHandler 补损 HTTP 处理器
 type SrpHandler struct {
-	svc           *service.SrpService
-	sysConfigRepo *repository.SysConfigRepository
+	svc *service.SrpService
 }
 
 func NewSrpHandler() *SrpHandler {
 	return &SrpHandler{
-		svc:           service.NewSrpService(),
-		sysConfigRepo: repository.NewSysConfigRepository(),
+		svc: service.NewSrpService(),
 	}
 }
 
@@ -84,10 +80,7 @@ type UpdateSrpConfigRequest struct {
 
 // GetSrpConfig GET /srp/config
 func (h *SrpHandler) GetSrpConfig(c *gin.Context) {
-	amountLimit := h.sysConfigRepo.GetFloat(
-		model.SysConfigSRPAmountLimit,
-		model.SysConfigDefaultSRPAmountLimit,
-	)
+	amountLimit := h.svc.GetSrpAmountLimit()
 	response.OK(c, SrpConfigResponse{AmountLimit: amountLimit})
 }
 
@@ -97,11 +90,7 @@ func (h *SrpHandler) UpdateSrpConfig(c *gin.Context) {
 	if !bindJSON(c, &req) {
 		return
 	}
-	if err := h.sysConfigRepo.Set(
-		model.SysConfigSRPAmountLimit,
-		fmt.Sprintf("%g", *req.AmountLimit),
-		"SRP 职权单笔审批/发放上限（ISK）",
-	); err != nil {
+	if err := h.svc.UpdateSrpAmountLimit(*req.AmountLimit); err != nil {
 		response.Fail(c, response.CodeBizError, "更新 SRP 配置失败")
 		return
 	}
@@ -226,8 +215,8 @@ func (h *SrpHandler) ListApplications(c *gin.Context) {
 		return
 	}
 
-	filter := repository.SrpApplicationFilter{
-		Tab:          repository.SrpTabType(c.Query("tab")),
+	filter := service.SrpApplicationFilter{
+		Tab:          c.Query("tab"),
 		ReviewStatus: c.Query("review_status"),
 		PayoutStatus: c.Query("payout_status"),
 		Keyword:      c.Query("keyword"),

--- a/server/internal/handler/sys_config.go
+++ b/server/internal/handler/sys_config.go
@@ -1,19 +1,18 @@
 package handler
 
 import (
+	"errors"
+
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
-	"amiya-eden/internal/utils"
 	"amiya-eden/pkg/response"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
 
 type SysConfigHandler struct {
-	repo   *repository.SysConfigRepository
+	cfgSvc *service.SysConfigService
 	sdeSvc sdeSysConfigService
 }
 
@@ -24,15 +23,15 @@ type sdeSysConfigService interface {
 }
 
 func NewSysConfigHandler() *SysConfigHandler {
-	return newSysConfigHandlerWithDeps(repository.NewSysConfigRepository(), service.NewSdeService())
+	return newSysConfigHandlerWithDeps(service.NewSysConfigService(), service.NewSdeService())
 }
 
 func newSysConfigHandlerWithDeps(
-	repo *repository.SysConfigRepository,
+	cfgSvc *service.SysConfigService,
 	sdeSvc sdeSysConfigService,
 ) *SysConfigHandler {
 	return &SysConfigHandler{
-		repo:   repo,
+		cfgSvc: cfgSvc,
 		sdeSvc: sdeSvc,
 	}
 }
@@ -56,14 +55,12 @@ type UpdateSDEConfigRequest struct {
 }
 
 func (h *SysConfigHandler) GetSDEConfig(c *gin.Context) {
-	apiKey, _ := h.repo.Get(model.SysConfigSDEAPIKey, model.SysConfigDefaultSDEAPIKey)
-	proxy, _ := h.repo.Get(model.SysConfigSDEProxy, model.SysConfigDefaultSDEProxy)
-	downloadURL, _ := h.repo.Get(model.SysConfigSDEDownloadURL, model.SysConfigDefaultSDEDownloadURL)
+	config := h.cfgSvc.GetSDEConfig()
 
 	response.OK(c, SDEConfigResponse{
-		APIKey:      apiKey,
-		Proxy:       proxy,
-		DownloadURL: downloadURL,
+		APIKey:      config.APIKey,
+		Proxy:       config.Proxy,
+		DownloadURL: config.DownloadURL,
 	})
 }
 
@@ -74,25 +71,9 @@ func (h *SysConfigHandler) UpdateSDEConfig(c *gin.Context) {
 		return
 	}
 
-	if req.APIKey != nil {
-		if err := h.repo.Set(model.SysConfigSDEAPIKey, *req.APIKey, "SDE 查询 API Key"); err != nil {
-			response.Fail(c, response.CodeBizError, "更新 API Key 失败")
-			return
-		}
-	}
-
-	if req.Proxy != nil {
-		if err := h.repo.Set(model.SysConfigSDEProxy, *req.Proxy, "SDE 下载代理"); err != nil {
-			response.Fail(c, response.CodeBizError, "更新代理配置失败")
-			return
-		}
-	}
-
-	if req.DownloadURL != nil {
-		if err := h.repo.Set(model.SysConfigSDEDownloadURL, *req.DownloadURL, "SDE 下载地址"); err != nil {
-			response.Fail(c, response.CodeBizError, "更新下载地址失败")
-			return
-		}
+	if err := h.cfgSvc.UpdateSDEConfig(req.APIKey, req.Proxy, req.DownloadURL); err != nil {
+		response.Fail(c, response.CodeBizError, err.Error())
+		return
 	}
 
 	response.OK(c, nil)
@@ -143,7 +124,7 @@ type UpdateCharacterESIRestrictionConfigRequest struct {
 
 func (h *SysConfigHandler) GetAllowCorporations(c *gin.Context) {
 	response.OK(c, AllowCorporationsResponse{
-		AllowCorporations: utils.GetAllowCorporations(),
+		AllowCorporations: h.cfgSvc.GetAllowCorporations(),
 	})
 }
 
@@ -153,28 +134,21 @@ func (h *SysConfigHandler) UpdateAllowCorporations(c *gin.Context) {
 		response.Fail(c, response.CodeParamError, "请求参数错误")
 		return
 	}
-	if err := utils.ValidateAllowCorporations(req.AllowCorporations); err != nil {
-		response.Fail(c, response.CodeParamError, "军团 ID 必须为正整数")
+	if err := h.cfgSvc.UpdateAllowCorporations(req.AllowCorporations); err != nil {
+		if errors.Is(err, service.ErrInvalidAllowCorporations) {
+			response.Fail(c, response.CodeParamError, err.Error())
+			return
+		}
+		response.Fail(c, response.CodeBizError, err.Error())
 		return
 	}
-
-	normalizedAllowCorporations := utils.NormalizeAllowCorporations(req.AllowCorporations)
-	if err := h.repo.SetInt64Slice(model.SysConfigAllowCorporations, normalizedAllowCorporations, "允许访问的公司 ID 列表"); err != nil {
-		response.Fail(c, response.CodeBizError, "更新允许的军团列表失败")
-		return
-	}
-
-	utils.InvalidateAllowCorporationsCache()
 
 	response.OK(c, nil)
 }
 
 func (h *SysConfigHandler) GetCharacterESIRestrictionConfig(c *gin.Context) {
 	response.OK(c, CharacterESIRestrictionConfigResponse{
-		EnforceCharacterESIRestriction: h.repo.GetBool(
-			model.SysConfigEnforceCharacterESIRestriction,
-			model.SysConfigDefaultEnforceCharacterESIRestriction,
-		),
+		EnforceCharacterESIRestriction: h.cfgSvc.GetCharacterESIRestrictionConfig(),
 	})
 }
 
@@ -194,12 +168,8 @@ func (h *SysConfigHandler) UpdateCharacterESIRestrictionConfig(c *gin.Context) {
 		return
 	}
 
-	if err := h.repo.Set(
-		model.SysConfigEnforceCharacterESIRestriction,
-		strconv.FormatBool(*req.EnforceCharacterESIRestriction),
-		"是否强制限制失效人物 ESI 停留在人物页面",
-	); err != nil {
-		response.Fail(c, response.CodeBizError, "更新人物 ESI 限制配置失败")
+	if err := h.cfgSvc.UpdateCharacterESIRestrictionConfig(*req.EnforceCharacterESIRestriction); err != nil {
+		response.Fail(c, response.CodeBizError, err.Error())
 		return
 	}
 

--- a/server/internal/handler/sys_config_sde_status_test.go
+++ b/server/internal/handler/sys_config_sde_status_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 	"encoding/json"
@@ -37,7 +36,7 @@ func TestGetSDEStatus(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(rec)
 	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/v1/system/sde-config/status", nil)
 
-	handler := newSysConfigHandlerWithDeps(repository.NewSysConfigRepository(), stubSDEStatusService{
+	handler := newSysConfigHandlerWithDeps(service.NewSysConfigService(), stubSDEStatusService{
 		status: service.SDEStatus{
 			CurrentVersion:   "v1",
 			LatestVersion:    "v2",
@@ -67,7 +66,7 @@ func TestCheckSDEVersionReturnsBizErrorOnFailure(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(rec)
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/system/sde-config/check", nil)
 
-	handler := newSysConfigHandlerWithDeps(repository.NewSysConfigRepository(), stubSDEStatusService{
+	handler := newSysConfigHandlerWithDeps(service.NewSysConfigService(), stubSDEStatusService{
 		checkErr: errors.New("upstream down"),
 	})
 	handler.CheckSDEVersion(ctx)
@@ -87,7 +86,7 @@ func TestTriggerSDEUpdateReturnsBizErrorOnFailure(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(rec)
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/system/sde-config/update", nil)
 
-	handler := newSysConfigHandlerWithDeps(repository.NewSysConfigRepository(), stubSDEStatusService{
+	handler := newSysConfigHandlerWithDeps(service.NewSysConfigService(), stubSDEStatusService{
 		updateErr: errors.New("import failed"),
 	})
 	handler.TriggerSDEUpdate(ctx)

--- a/server/internal/handler/sys_wallet.go
+++ b/server/internal/handler/sys_wallet.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"amiya-eden/internal/middleware"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 
@@ -73,7 +72,7 @@ func (h *SysWalletHandler) AdminListWallets(c *gin.Context) {
 		req.Size = 20
 	}
 	req.Current, req.Size = normalizeLedgerPagination(req.Current, req.Size)
-	filter := repository.WalletListFilter{UserKeyword: req.UserKeyword}
+	filter := service.WalletListFilter{UserKeyword: req.UserKeyword}
 
 	wallets, total, err := h.svc.AdminListWallets(req.Current, req.Size, filter)
 	if err != nil {
@@ -142,7 +141,7 @@ func (h *SysWalletHandler) AdminListTransactions(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizeLedgerPagination(req.Current, req.Size)
 
-	filter := repository.WalletTransactionFilter{
+	filter := service.WalletTransactionFilter{
 		UserID:      req.UserID,
 		UserKeyword: req.UserKeyword,
 		RefType:     req.RefType,
@@ -175,7 +174,7 @@ func (h *SysWalletHandler) AdminListLogs(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizeLedgerPagination(req.Current, req.Size)
 
-	filter := repository.WalletLogFilter{
+	filter := service.WalletLogFilter{
 		OperatorID: req.OperatorID,
 		TargetUID:  req.TargetUID,
 		Action:     req.Action,

--- a/server/internal/handler/ticket.go
+++ b/server/internal/handler/ticket.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 
@@ -111,7 +110,7 @@ func (h *TicketHandler) AdminListTickets(c *gin.Context) {
 		response.Fail(c, response.CodeParamError, err.Error())
 		return
 	}
-	filter := repository.TicketListFilter{
+	filter := service.TicketListFilter{
 		Status:  c.Query("status"),
 		Keyword: c.Query("keyword"),
 	}

--- a/server/internal/handler/user.go
+++ b/server/internal/handler/user.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/internal/utils"
 	"amiya-eden/pkg/response"
@@ -27,7 +26,7 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 		return
 	}
 
-	filter := repository.UserFilter{
+	filter := service.UserFilter{
 		Keyword: c.Query("keyword"),
 		Role:    c.Query("role"),
 	}

--- a/server/internal/handler/welfare.go
+++ b/server/internal/handler/welfare.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"amiya-eden/internal/middleware"
 	"amiya-eden/internal/model"
-	"amiya-eden/internal/repository"
 	"amiya-eden/internal/service"
 	"amiya-eden/pkg/response"
 	"strings"
@@ -157,7 +156,7 @@ func (h *WelfareHandler) AdminListWelfares(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizePagination(req.Current, req.Size, 20, 100)
 
-	filter := repository.WelfareFilter{
+	filter := service.WelfareFilter{
 		Status: req.Status,
 		Name:   req.Name,
 	}
@@ -267,7 +266,7 @@ func (h *WelfareHandler) AdminListApplications(c *gin.Context) {
 	}
 	req.Current, req.Size = normalizeLedgerPagination(req.Current, req.Size)
 
-	var filter repository.WelfareApplicationFilter
+	var filter service.WelfareApplicationFilter
 	if strings.Contains(req.Status, ",") {
 		filter.StatusIn = strings.Split(req.Status, ",")
 	} else {

--- a/server/internal/service/alliance_pap.go
+++ b/server/internal/service/alliance_pap.go
@@ -32,6 +32,30 @@ func NewAlliancePAPService() *AlliancePAPService {
 	}
 }
 
+func (s *AlliancePAPService) GetMyPAPByUserID(userID uint, year, month int) (*AlliancePAPResult, error) {
+	user, err := s.userRepo.GetByID(userID)
+	if err != nil || user.PrimaryCharacterID == 0 {
+		return nil, fmt.Errorf("未设置主人物")
+	}
+	char, err := s.charRepo.GetByCharacterID(user.PrimaryCharacterID)
+	if err != nil {
+		return nil, fmt.Errorf("主人物不存在")
+	}
+	return s.GetMyPAP(char.CharacterName, year, month)
+}
+
+func (s *AlliancePAPService) ImportAlliancePAPByPrimaryCharacter(year, month int, data *PAPImportInfo) error {
+	char, err := s.charRepo.GetByCharacterName(data.PrimaryCharacterName)
+	if err != nil {
+		return fmt.Errorf("主人物不存在")
+	}
+	user, err := s.userRepo.GetByPrimaryCharacterID(char.CharacterID)
+	if err != nil || user.PrimaryCharacterID == 0 {
+		return fmt.Errorf("未设置主人物")
+	}
+	return s.ImportAlliancePAP(year, month, data, char)
+}
+
 // ─── 外部 API 响应结构 ───
 
 type alliancePAPAPIResponse struct {

--- a/server/internal/service/audit_service.go
+++ b/server/internal/service/audit_service.go
@@ -30,6 +30,19 @@ type AuditRecordInput struct {
 	Details      map[string]any
 }
 
+type AuditEventFilter struct {
+	StartDate    *time.Time
+	EndDate      *time.Time
+	Category     string
+	Action       string
+	ActorUserID  *uint
+	TargetUserID *uint
+	Result       string
+	RequestID    string
+	ResourceID   string
+	Keyword      string
+}
+
 type AuditService struct {
 	repo *repository.AuditEventRepository
 }
@@ -98,15 +111,16 @@ func (s *AuditService) RecordEvent(_ context.Context, in AuditRecordInput) error
 	return nil
 }
 
-func (s *AuditService) AdminListAuditEvents(page, size int, filter repository.AuditEventFilter) ([]model.AuditEvent, int64, error) {
+func (s *AuditService) AdminListAuditEvents(page, size int, filter AuditEventFilter) ([]model.AuditEvent, int64, error) {
 	page = normalizePage(page)
 	size = normalizeLedgerPageSize(size)
 
-	records, err := s.repo.List(page, size, filter)
+	repoFilter := toRepositoryAuditEventFilter(filter)
+	records, err := s.repo.List(page, size, repoFilter)
 	if err != nil {
 		return nil, 0, err
 	}
-	total, err := s.repo.Count(filter)
+	total, err := s.repo.Count(repoFilter)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -125,7 +139,7 @@ func isAuditTableMissingError(err error) bool {
 type AuditExportTaskCreateInput struct {
 	OperatorUserID uint
 	Format         string
-	Filter         repository.AuditEventFilter
+	Filter         AuditEventFilter
 	RequestID      string
 	IP             string
 	UserAgent      string
@@ -148,7 +162,7 @@ func (s *AuditService) CreateExportTask(ctx context.Context, in AuditExportTaskC
 		return nil, fmt.Errorf("unsupported format: %s", in.Format)
 	}
 
-	filterJSON, err := repository.EncodeAuditEventFilter(in.Filter)
+	filterJSON, err := repository.EncodeAuditEventFilter(toRepositoryAuditEventFilter(in.Filter))
 	if err != nil {
 		return nil, err
 	}
@@ -325,6 +339,21 @@ func (s *AuditService) generateExportFile(ctx context.Context, taskID string) er
 		},
 	})
 	return nil
+}
+
+func toRepositoryAuditEventFilter(filter AuditEventFilter) repository.AuditEventFilter {
+	return repository.AuditEventFilter{
+		StartDate:    filter.StartDate,
+		EndDate:      filter.EndDate,
+		Category:     filter.Category,
+		Action:       filter.Action,
+		ActorUserID:  filter.ActorUserID,
+		TargetUserID: filter.TargetUserID,
+		Result:       filter.Result,
+		RequestID:    filter.RequestID,
+		ResourceID:   filter.ResourceID,
+		Keyword:      filter.Keyword,
+	}
 }
 
 func writeAuditRowsJSON(path string, rows []model.AuditEvent) error {

--- a/server/internal/service/auto_role.go
+++ b/server/internal/service/auto_role.go
@@ -24,6 +24,8 @@ type AutoRoleService struct {
 	auditSvc     *AuditService
 }
 
+type CorpTitleInfo = repository.CorpTitleInfo
+
 func NewAutoRoleService() *AutoRoleService {
 	return &AutoRoleService{
 		autoRoleRepo: repository.NewAutoRoleRepository(),
@@ -142,7 +144,7 @@ func (s *AutoRoleService) ListEsiTitleMappings() ([]model.EsiTitleMapping, error
 }
 
 // ListCorpTitles 获取数据库中所有去重的军团头衔（用于前端下拉选择）
-func (s *AutoRoleService) ListCorpTitles(ctx context.Context) ([]repository.CorpTitleInfo, error) {
+func (s *AutoRoleService) ListCorpTitles(ctx context.Context) ([]CorpTitleInfo, error) {
 	titles, err := s.autoRoleRepo.ListDistinctCorpTitles()
 	if err != nil {
 		return nil, fmt.Errorf("list distinct corp titles: %w", err)

--- a/server/internal/service/fleet.go
+++ b/server/internal/service/fleet.go
@@ -37,6 +37,9 @@ type FleetService struct {
 	esiClient  *esi.Client
 }
 
+type MemberWithPap = repository.MemberWithPap
+type PapLogDetail = repository.PapLogDetail
+
 func NewFleetService() *FleetService {
 	return &FleetService{
 		repo:       repository.NewFleetRepository(),
@@ -216,6 +219,11 @@ type ManualAddFleetMembersResult struct {
 	MissingCharacterNames []string `json:"missing_character_names"`
 }
 
+type FleetFilter struct {
+	Importance string
+	FCUserID   *uint
+}
+
 // UpdateFleet 更新舰队信息
 func (s *FleetService) UpdateFleet(fleetID string, userID uint, userRoles []string, req *UpdateFleetRequest) (*model.Fleet, error) {
 	fleet, err := s.repo.GetByID(fleetID)
@@ -333,9 +341,12 @@ func (s *FleetService) RefreshESIFleetID(fleetID string, userID uint, userRoles 
 }
 
 // ListFleets 分页查询舰队列表
-func (s *FleetService) ListFleets(page, pageSize int, filter repository.FleetFilter) ([]model.FleetListItem, int64, error) {
+func (s *FleetService) ListFleets(page, pageSize int, filter FleetFilter) ([]model.FleetListItem, int64, error) {
 	normalizePageRequest(&page, &pageSize, 10, 100)
-	return s.repo.List(page, pageSize, filter)
+	return s.repo.List(page, pageSize, repository.FleetFilter{
+		Importance: filter.Importance,
+		FCUserID:   filter.FCUserID,
+	})
 }
 
 // GetMyFleets 返回当前用户参与过的舰队列表（按 fleet_member.user_id 过滤）
@@ -769,7 +780,7 @@ func (s *FleetService) getPAPFCSalaryMonthlyLimit() int {
 }
 
 // ListMembersWithPap 分页查询舰队成员（含 PAP 信息）
-func (s *FleetService) ListMembersWithPap(fleetID string, page, pageSize int) ([]repository.MemberWithPap, int64, error) {
+func (s *FleetService) ListMembersWithPap(fleetID string, page, pageSize int) ([]MemberWithPap, int64, error) {
 	normalizePageRequest(&page, &pageSize, 260, 260)
 	return s.repo.ListMembersWithPap(fleetID, page, pageSize)
 }
@@ -821,7 +832,7 @@ func (s *FleetService) GetPapLogs(fleetID string) ([]model.FleetPapLog, error) {
 }
 
 // GetUserPapLogs 获取用户的 PAP 记录（含人物名、FC 名称、舰队信息）
-func (s *FleetService) GetUserPapLogs(userID uint) ([]repository.PapLogDetail, error) {
+func (s *FleetService) GetUserPapLogs(userID uint) ([]PapLogDetail, error) {
 	return s.repo.ListPapLogsDetailByUser(userID)
 }
 

--- a/server/internal/service/sde.go
+++ b/server/internal/service/sde.go
@@ -39,6 +39,10 @@ var sdeUpdateState = struct {
 	lastSeenVersion string
 }{}
 
+type TypeInfo = repository.TypeInfo
+type SdeNameMap = repository.SdeNameMap
+type FuzzySearchItem = repository.FuzzySearchItem
+
 // SdeService SDE 业务逻辑层
 type SdeService struct {
 	repo      *repository.SdeRepository
@@ -953,16 +957,16 @@ func truncate(s string, n int) string {
 // ---- 数据查询 ----
 
 // GetTypes 批量查询物品信息（含 group + category + market_group 翻译）
-func (s *SdeService) GetTypes(typeIDs []int, published *bool, languageID string) ([]repository.TypeInfo, error) {
+func (s *SdeService) GetTypes(typeIDs []int, published *bool, languageID string) ([]TypeInfo, error) {
 	return s.repo.GetTypes(typeIDs, published, languageID)
 }
 
 // GetNames 批量查询按 namespace 分组的 id -> name 映射（仅查数据库翻译表）
-func (s *SdeService) GetNames(ids map[string][]int, languageID string) (repository.SdeNameMap, error) {
+func (s *SdeService) GetNames(ids map[string][]int, languageID string) (SdeNameMap, error) {
 	return s.repo.GetNames(ids, languageID)
 }
 
 // FuzzySearch 模糊搜索物品/成员名称
-func (s *SdeService) FuzzySearch(keyword string, languageID string, categoryIDs []int, excludeCategoryIDs []int, limit int, searchMember bool) ([]repository.FuzzySearchItem, error) {
+func (s *SdeService) FuzzySearch(keyword string, languageID string, categoryIDs []int, excludeCategoryIDs []int, limit int, searchMember bool) ([]FuzzySearchItem, error) {
 	return s.repo.FuzzySearch(keyword, languageID, categoryIDs, excludeCategoryIDs, limit, searchMember)
 }

--- a/server/internal/service/shop.go
+++ b/server/internal/service/shop.go
@@ -353,21 +353,45 @@ type AdminProductUpdateRequest struct {
 	SortOrder   *int     `json:"sort_order"`
 }
 
+type ProductFilter struct {
+	Status *int8
+	Type   string
+	Name   string
+}
+
+type OrderFilter struct {
+	UserID    *uint
+	ProductID *uint
+	Status    string
+	Statuses  []string
+	Keyword   string
+}
+
 // AdminDeleteProduct 删除商品
 func (s *ShopService) AdminDeleteProduct(id uint) error {
 	return s.repo.DeleteProduct(id)
 }
 
 // AdminListProducts 管理员查询商品（包含下架）
-func (s *ShopService) AdminListProducts(page, pageSize int, filter repository.ProductFilter) ([]model.ShopProduct, int64, error) {
+func (s *ShopService) AdminListProducts(page, pageSize int, filter ProductFilter) ([]model.ShopProduct, int64, error) {
 	normalizePageRequest(&page, &pageSize, 20, 100)
-	return s.repo.ListProducts(page, pageSize, filter)
+	return s.repo.ListProducts(page, pageSize, repository.ProductFilter{
+		Status: filter.Status,
+		Type:   filter.Type,
+		Name:   filter.Name,
+	})
 }
 
 // AdminListOrders 管理员查询订单
-func (s *ShopService) AdminListOrders(page, pageSize int, filter repository.OrderFilter) ([]ShopOrderResponse, int64, error) {
+func (s *ShopService) AdminListOrders(page, pageSize int, filter OrderFilter) ([]ShopOrderResponse, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
-	orders, total, err := s.repo.ListOrders(page, pageSize, filter)
+	orders, total, err := s.repo.ListOrders(page, pageSize, repository.OrderFilter{
+		UserID:    filter.UserID,
+		ProductID: filter.ProductID,
+		Status:    filter.Status,
+		Statuses:  filter.Statuses,
+		Keyword:   filter.Keyword,
+	})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/internal/service/srp.go
+++ b/server/internal/service/srp.go
@@ -63,6 +63,16 @@ const (
 	SrpPayoutModeFuxiCoin       = "fuxi_coin"
 )
 
+type SrpApplicationFilter struct {
+	Tab          string
+	UserID       *uint
+	CharacterID  *int64
+	FleetID      *string
+	ReviewStatus string
+	PayoutStatus string
+	Keyword      string
+}
+
 // ─────────────────────────────────────────────
 //  KM 解析辅助
 // ─────────────────────────────────────────────
@@ -372,10 +382,18 @@ func (s *SrpService) enrichWithFleetInfo(apps []model.SrpApplication) []SrpAppli
 }
 
 // ListApplications 管理员端分页查询申请列表
-func (s *SrpService) ListApplications(page, pageSize int, filter repository.SrpApplicationFilter) ([]SrpApplicationResponse, int64, error) {
+func (s *SrpService) ListApplications(page, pageSize int, filter SrpApplicationFilter) ([]SrpApplicationResponse, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
 
-	apps, total, err := s.repo.ListApplications(page, pageSize, filter)
+	apps, total, err := s.repo.ListApplications(page, pageSize, repository.SrpApplicationFilter{
+		Tab:          repository.SrpTabType(filter.Tab),
+		UserID:       filter.UserID,
+		CharacterID:  filter.CharacterID,
+		FleetID:      filter.FleetID,
+		ReviewStatus: filter.ReviewStatus,
+		PayoutStatus: filter.PayoutStatus,
+		Keyword:      filter.Keyword,
+	})
 	if err != nil {
 		return nil, 0, err
 	}
@@ -533,6 +551,18 @@ func applyAutoApprovalToApplication(
 // srpAmountLimit 从系统配置读取 SRP 职权单笔上限（ISK），10 分钟 Redis 缓存
 func (s *SrpService) srpAmountLimit() float64 {
 	return s.sysConfigRepo.GetFloat(model.SysConfigSRPAmountLimit, model.SysConfigDefaultSRPAmountLimit)
+}
+
+func (s *SrpService) GetSrpAmountLimit() float64 {
+	return s.srpAmountLimit()
+}
+
+func (s *SrpService) UpdateSrpAmountLimit(amountLimit float64) error {
+	return s.sysConfigRepo.Set(
+		model.SysConfigSRPAmountLimit,
+		fmt.Sprintf("%g", amountLimit),
+		"SRP 职权单笔审批/发放上限（ISK）",
+	)
 }
 
 // srpCallerHasAmountLimit 判断调用者是否受 SRP 单笔上限约束

--- a/server/internal/service/srp_test.go
+++ b/server/internal/service/srp_test.go
@@ -1062,7 +1062,7 @@ func TestListApplicationsRefreshesRecommendedAmountUsingFleetConfigFirst(t *test
 	}
 
 	svc := newSrpServiceForTests()
-	list, total, err := svc.ListApplications(1, 20, repository.SrpApplicationFilter{Tab: repository.SrpTabPending})
+	list, total, err := svc.ListApplications(1, 20, SrpApplicationFilter{Tab: string(repository.SrpTabPending)})
 	if err != nil {
 		t.Fatalf("ListApplications() error = %v", err)
 	}

--- a/server/internal/service/sys_config.go
+++ b/server/internal/service/sys_config.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"errors"
+	"strconv"
+
+	"amiya-eden/internal/model"
+	"amiya-eden/internal/repository"
+	"amiya-eden/internal/utils"
+)
+
+var ErrInvalidAllowCorporations = errors.New("军团 ID 必须为正整数")
+
+type SysConfigService struct {
+	repo *repository.SysConfigRepository
+}
+
+type SDEConfig struct {
+	APIKey      string
+	Proxy       string
+	DownloadURL string
+}
+
+func NewSysConfigService() *SysConfigService {
+	return NewSysConfigServiceWithRepository(repository.NewSysConfigRepository())
+}
+
+func NewSysConfigServiceWithRepository(repo *repository.SysConfigRepository) *SysConfigService {
+	return &SysConfigService{repo: repo}
+}
+
+func (s *SysConfigService) GetSDEConfig() SDEConfig {
+	apiKey, _ := s.repo.Get(model.SysConfigSDEAPIKey, model.SysConfigDefaultSDEAPIKey)
+	proxy, _ := s.repo.Get(model.SysConfigSDEProxy, model.SysConfigDefaultSDEProxy)
+	downloadURL, _ := s.repo.Get(model.SysConfigSDEDownloadURL, model.SysConfigDefaultSDEDownloadURL)
+
+	return SDEConfig{
+		APIKey:      apiKey,
+		Proxy:       proxy,
+		DownloadURL: downloadURL,
+	}
+}
+
+func (s *SysConfigService) UpdateSDEConfig(apiKey, proxy, downloadURL *string) error {
+	if apiKey != nil {
+		if err := s.repo.Set(model.SysConfigSDEAPIKey, *apiKey, "SDE 查询 API Key"); err != nil {
+			return errors.New("更新 API Key 失败")
+		}
+	}
+	if proxy != nil {
+		if err := s.repo.Set(model.SysConfigSDEProxy, *proxy, "SDE 下载代理"); err != nil {
+			return errors.New("更新代理配置失败")
+		}
+	}
+	if downloadURL != nil {
+		if err := s.repo.Set(model.SysConfigSDEDownloadURL, *downloadURL, "SDE 下载地址"); err != nil {
+			return errors.New("更新下载地址失败")
+		}
+	}
+	return nil
+}
+
+func (s *SysConfigService) GetAllowCorporations() []int64 {
+	return utils.GetAllowCorporations()
+}
+
+func (s *SysConfigService) UpdateAllowCorporations(allowCorporations []int64) error {
+	if err := utils.ValidateAllowCorporations(allowCorporations); err != nil {
+		return ErrInvalidAllowCorporations
+	}
+	normalizedAllowCorporations := utils.NormalizeAllowCorporations(allowCorporations)
+	if err := s.repo.SetInt64Slice(model.SysConfigAllowCorporations, normalizedAllowCorporations, "允许访问的公司 ID 列表"); err != nil {
+		return errors.New("更新允许的军团列表失败")
+	}
+	utils.InvalidateAllowCorporationsCache()
+	return nil
+}
+
+func (s *SysConfigService) GetCharacterESIRestrictionConfig() bool {
+	return s.repo.GetBool(
+		model.SysConfigEnforceCharacterESIRestriction,
+		model.SysConfigDefaultEnforceCharacterESIRestriction,
+	)
+}
+
+func (s *SysConfigService) UpdateCharacterESIRestrictionConfig(enforce bool) error {
+	if err := s.repo.Set(
+		model.SysConfigEnforceCharacterESIRestriction,
+		strconv.FormatBool(enforce),
+		"是否强制限制失效人物 ESI 停留在人物页面",
+	); err != nil {
+		return errors.New("更新人物 ESI 限制配置失败")
+	}
+	return nil
+}

--- a/server/internal/service/sys_wallet.go
+++ b/server/internal/service/sys_wallet.go
@@ -22,6 +22,22 @@ type SysWalletService struct {
 
 const walletTransactionReasonMaxLength = 256
 
+type WalletListFilter struct {
+	UserKeyword string
+}
+
+type WalletTransactionFilter struct {
+	UserID      *uint
+	UserKeyword string
+	RefType     string
+}
+
+type WalletLogFilter struct {
+	OperatorID *uint
+	TargetUID  *uint
+	Action     string
+}
+
 func buildWalletTransaction(userID uint, operatorID uint, delta float64, newBalance float64, reason, refType, refID string) *model.WalletTransaction {
 	if reasonRunes := []rune(reason); len(reasonRunes) > walletTransactionReasonMaxLength {
 		reason = string(reasonRunes[:walletTransactionReasonMaxLength])
@@ -281,9 +297,11 @@ func (s *SysWalletService) AdminAdjust(operatorID uint, req *AdminAdjustRequest)
 }
 
 // AdminListWallets 管理员查询所有钱包（附带主人物名）
-func (s *SysWalletService) AdminListWallets(page, pageSize int, filter repository.WalletListFilter) ([]model.WalletWithCharacter, int64, error) {
+func (s *SysWalletService) AdminListWallets(page, pageSize int, filter WalletListFilter) ([]model.WalletWithCharacter, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
-	return s.repo.ListWalletsWithCharacter(page, pageSize, filter)
+	return s.repo.ListWalletsWithCharacter(page, pageSize, repository.WalletListFilter{
+		UserKeyword: filter.UserKeyword,
+	})
 }
 
 // AdminGetWallet 管理员查看指定用户钱包
@@ -292,15 +310,23 @@ func (s *SysWalletService) AdminGetWallet(userID uint) (*model.SystemWallet, err
 }
 
 // AdminListTransactions 管理员查询流水（可按用户/类型筛选，附带人物名）
-func (s *SysWalletService) AdminListTransactions(page, pageSize int, filter repository.WalletTransactionFilter) ([]model.TransactionWithCharacter, int64, error) {
+func (s *SysWalletService) AdminListTransactions(page, pageSize int, filter WalletTransactionFilter) ([]model.TransactionWithCharacter, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
-	return s.repo.ListTransactionsWithCharacter(page, pageSize, filter)
+	return s.repo.ListTransactionsWithCharacter(page, pageSize, repository.WalletTransactionFilter{
+		UserID:      filter.UserID,
+		UserKeyword: filter.UserKeyword,
+		RefType:     filter.RefType,
+	})
 }
 
 // AdminListLogs 管理员查询操作日志（附带人物名）
-func (s *SysWalletService) AdminListLogs(page, pageSize int, filter repository.WalletLogFilter) ([]model.LogWithCharacter, int64, error) {
+func (s *SysWalletService) AdminListLogs(page, pageSize int, filter WalletLogFilter) ([]model.LogWithCharacter, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
-	return s.repo.ListLogsWithCharacter(page, pageSize, filter)
+	return s.repo.ListLogsWithCharacter(page, pageSize, repository.WalletLogFilter{
+		OperatorID: filter.OperatorID,
+		TargetUID:  filter.TargetUID,
+		Action:     filter.Action,
+	})
 }
 
 func (s *SysWalletService) AdminGetAnalytics(req *WalletAnalyticsRequest) (*WalletAnalyticsResponse, error) {

--- a/server/internal/service/ticket.go
+++ b/server/internal/service/ticket.go
@@ -24,6 +24,14 @@ type TicketService struct {
 	auditSvc *AuditService
 }
 
+type TicketListFilter struct {
+	Status   string
+	Statuses []string
+	Category uint
+	UserID   uint
+	Keyword  string
+}
+
 func NewTicketService() *TicketService {
 	return &TicketService{repo: repository.NewTicketRepository(), auditSvc: NewAuditService()}
 }
@@ -109,7 +117,7 @@ func (s *TicketService) GetAdminTicketDetail(ticketID uint) (*model.TicketListIt
 	return ticket, nil
 }
 
-func (s *TicketService) ListTicketsAdmin(filter repository.TicketListFilter, page, pageSize int) ([]model.TicketListItem, int64, error) {
+func (s *TicketService) ListTicketsAdmin(filter TicketListFilter, page, pageSize int) ([]model.TicketListItem, int64, error) {
 	normalizePageRequest(&page, &pageSize, 20, 100)
 	filter.Keyword = strings.TrimSpace(filter.Keyword)
 	filter.Status = strings.TrimSpace(filter.Status)
@@ -133,7 +141,13 @@ func (s *TicketService) ListTicketsAdmin(filter repository.TicketListFilter, pag
 			filter.Status = normalizedStatus
 		}
 	}
-	return s.repo.ListTicketsAdmin(filter, page, pageSize)
+	return s.repo.ListTicketsAdmin(repository.TicketListFilter{
+		Status:   filter.Status,
+		Statuses: filter.Statuses,
+		Category: filter.Category,
+		UserID:   filter.UserID,
+		Keyword:  filter.Keyword,
+	}, page, pageSize)
 }
 
 func (s *TicketService) AddReplyAsUser(userID, ticketID uint, content string) (*model.TicketReplyItem, error) {

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -36,6 +36,13 @@ type UserPatch struct {
 	Status    *int8
 }
 
+type UserFilter struct {
+	Keyword           string
+	Status            *int
+	Role              string
+	AllowCorporations []int64
+}
+
 func NewUserService() *UserService {
 	return &UserService{
 		repo:      repository.NewUserRepository(),
@@ -50,9 +57,34 @@ func (s *UserService) GetUserByID(id uint) (*model.User, error) {
 	return s.repo.GetByID(id)
 }
 
-func (s *UserService) ListUsers(page, pageSize int, filter repository.UserFilter) ([]model.UserListItem, int64, error) {
+func (s *UserService) ListUserCharacters(userID uint) ([]model.EveCharacter, error) {
+	return s.charRepo.ListByUserID(userID)
+}
+
+func (s *UserService) GetCharacterByID(characterID int64) (*model.EveCharacter, error) {
+	return s.charRepo.GetByCharacterID(characterID)
+}
+
+func (s *UserService) ListCharacterNamesByIDs(characterIDs []int64) map[int64]string {
+	characterNames := make(map[int64]string, len(characterIDs))
+	chars, err := s.charRepo.ListByCharacterIDs(characterIDs)
+	if err != nil {
+		return characterNames
+	}
+	for _, char := range chars {
+		characterNames[char.CharacterID] = char.CharacterName
+	}
+	return characterNames
+}
+
+func (s *UserService) ListUsers(page, pageSize int, filter UserFilter) ([]model.UserListItem, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
-	users, total, err := s.repo.List(page, pageSize, filter)
+	users, total, err := s.repo.List(page, pageSize, repository.UserFilter{
+		Keyword:           filter.Keyword,
+		Status:            filter.Status,
+		Role:              filter.Role,
+		AllowCorporations: filter.AllowCorporations,
+	})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/internal/service/welfare.go
+++ b/server/internal/service/welfare.go
@@ -112,6 +112,11 @@ type AdminUpdateWelfareRequest struct {
 	SortOrder              *int   `json:"sort_order"`
 }
 
+type WelfareFilter struct {
+	Status *int8
+	Name   string
+}
+
 // AdminUpdateWelfare 更新福利
 func (s *WelfareService) AdminUpdateWelfare(id uint, req *AdminUpdateWelfareRequest) (*model.Welfare, error) {
 	w, err := s.repo.GetWelfareByID(id)
@@ -191,9 +196,12 @@ func (s *WelfareService) AdminDeleteWelfare(id uint) error {
 }
 
 // AdminListWelfares 查询福利列表
-func (s *WelfareService) AdminListWelfares(page, pageSize int, filter repository.WelfareFilter) ([]model.Welfare, int64, error) {
+func (s *WelfareService) AdminListWelfares(page, pageSize int, filter WelfareFilter) ([]model.Welfare, int64, error) {
 	normalizePageRequest(&page, &pageSize, 20, 100)
-	return s.repo.ListWelfares(page, pageSize, filter)
+	return s.repo.ListWelfares(page, pageSize, repository.WelfareFilter{
+		Status: filter.Status,
+		Name:   filter.Name,
+	})
 }
 
 // AdminReorderWelfares 按给定 ID 顺序更新 sort_order
@@ -1065,11 +1073,23 @@ type AdminApplicationResp struct {
 	ReviewedAt        *time.Time `json:"reviewed_at"`
 }
 
+type WelfareApplicationFilter struct {
+	Status               string
+	StatusIn             []string
+	Keyword              string
+	IncludeEvidenceImage bool
+}
+
 // AdminListApplications 管理端查询福利申请列表
-func (s *WelfareService) AdminListApplications(page, pageSize int, filter repository.WelfareApplicationFilter) ([]AdminApplicationResp, int64, error) {
+func (s *WelfareService) AdminListApplications(page, pageSize int, filter WelfareApplicationFilter) ([]AdminApplicationResp, int64, error) {
 	normalizeLedgerPageRequest(&page, &pageSize)
 
-	apps, total, err := s.repo.ListApplicationsPaginated(page, pageSize, filter)
+	apps, total, err := s.repo.ListApplicationsPaginated(page, pageSize, repository.WelfareApplicationFilter{
+		Status:               filter.Status,
+		StatusIn:             filter.StatusIn,
+		Keyword:              filter.Keyword,
+		IncludeEvidenceImage: filter.IncludeEvidenceImage,
+	})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/static/.env.development
+++ b/static/.env.development
@@ -13,4 +13,4 @@ VITE_API_PROXY_URL = http://localhost:8080
 VITE_DROP_CONSOLE = false
 
 # 版本信息（由 sync-version.js 自动同步）
-VITE_VERSION = 1.7.0
+VITE_VERSION = 1.8.0

--- a/static/.env.production
+++ b/static/.env.production
@@ -10,4 +10,4 @@ VITE_API_URL = /
 VITE_DROP_CONSOLE = true
 
 # 版本信息（由 sync-version.js 自动同步）
-VITE_VERSION = 1.7.0
+VITE_VERSION = 1.8.0

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "art-design-pro",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "engines": {
     "node": ">=20.19.0",

--- a/static/src/api/alliance-pap.ts
+++ b/static/src/api/alliance-pap.ts
@@ -1,4 +1,8 @@
+import axios from 'axios'
 import request from '@/utils/http'
+
+const defaultSeatUserAgent =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
 
 export interface AlliancePAPFleet {
   id: number
@@ -80,6 +84,59 @@ export interface PAPImportInfo {
   primary_character_name: string
   monthly_pap: number
   calculated_at: string
+}
+
+export interface SeatPapTrackingCredentials {
+  laravelSession: string
+  cfClearance?: string
+  userAgent?: string
+}
+
+export interface SeatPapTrackingItem {
+  character: string
+  pap_count: number | string | null
+  logoff_date: string | null
+}
+
+export interface SeatPapTrackingResponse {
+  data?: SeatPapTrackingItem[]
+}
+
+export function fetchSeatPapTracking(credentials: SeatPapTrackingCredentials) {
+  const { VITE_API_URL } = import.meta.env
+  const cookie =
+    `laravel_session=${credentials.laravelSession}` +
+    (credentials.cfClearance === '' || credentials.cfClearance == null
+      ? ''
+      : `;cf_clearance=${credentials.cfClearance}`)
+
+  const axiosInstance = axios.create({
+    timeout: 10000,
+    baseURL: VITE_API_URL,
+    headers: {
+      Accept: 'application/json, text/javascript, */*; q=0.01',
+      'X-Accept-Encoding': 'gzip, deflate, br, zstd',
+      'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',
+      'Cache-Control': 'no-cache',
+      // Contains user-provided SEAT session credentials; proxy/request logging must redact it.
+      'X-Cookie': cookie,
+      Pragma: 'no-cache',
+      Priority: 'u=1, i',
+      'X-Sec-Ch-Ua': `"Not:A-Brand";v="99", "Microsoft Edge";v="145", "Chromium";v="145"`,
+      'X-Sec-Ch-Ua-Mobile': '?0',
+      'X-Sec-Ch-Ua-Platform': `"Windows"`,
+      'X-Sec-Fetch-Dest': 'empty',
+      'X-Sec-Fetch-Mode': 'cors',
+      'X-Sec-Fetch-Site': 'same-origin',
+      'X-User-Agent':
+        credentials.userAgent === '' || credentials.userAgent == null
+          ? defaultSeatUserAgent
+          : credentials.userAgent,
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
+
+  return axiosInstance.get<SeatPapTrackingResponse>('/seatproxy/tools/paptracking')
 }
 
 export function importAlliancePAP(params?: { year?: number; month?: number; data: PAPImportInfo }) {

--- a/static/src/components/business/KmPreviewDialog.vue
+++ b/static/src/components/business/KmPreviewDialog.vue
@@ -70,9 +70,9 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n'
   import { ElDialog, ElButton, ElEmpty } from 'element-plus'
-  import { fetchKillmailDetail } from '@/api/srp'
   import { formatIskSmart, formatTime } from '@utils/common'
   import { useUserStore } from '@/store/modules/user'
+  import { useKillmailDetail } from '@/hooks/srp/useKillmailDetail'
 
   defineOptions({ name: 'KmPreviewDialog' })
 
@@ -84,6 +84,7 @@
 
   useI18n()
   const userStore = useUserStore()
+  const { fetchKillmailDetail } = useKillmailDetail()
 
   const loading = ref(false)
   const detail = ref<Api.Srp.KillmailDetailResponse | null>(null)

--- a/static/src/components/business/SdeSearchSelect.vue
+++ b/static/src/components/business/SdeSearchSelect.vue
@@ -41,11 +41,12 @@
   import { ref, watch } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { User } from '@element-plus/icons-vue'
-  import { fuzzySearch } from '@/api/sde'
   import { useUserStore } from '@/store/modules/user'
+  import { useSdeSearch } from '@/hooks/core/useSdeSearch'
 
   useI18n()
   const userStore = useUserStore()
+  const { fuzzySearch } = useSdeSearch()
 
   interface Props {
     /** 需要搜索的分类 ID 列表（仅搜索这些分类） */

--- a/static/src/components/core/banners/art-basic-banner/index.vue
+++ b/static/src/components/core/banners/art-basic-banner/index.vue
@@ -46,7 +46,7 @@
           }"
           @click.stop="emit('buttonClick')"
         >
-          {{ buttonConfig?.text }}
+          {{ buttonText }}
         </div>
       </slot>
 
@@ -60,7 +60,7 @@
         :src="imageConfig.src"
         :style="{ width: imageConfig.width, bottom: imageConfig.bottom, right: imageConfig.right }"
         loading="lazy"
-        alt="背景图片"
+        :alt="$t('banner.basic.backgroundAlt')"
       />
     </div>
   </div>
@@ -68,9 +68,11 @@
 
 <script setup lang="ts">
   import { onMounted, ref, computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
   import { useSettingStore } from '@/store/modules/setting'
   const settingStore = useSettingStore()
   const { isDark } = storeToRefs(settingStore)
+  const { t } = useI18n()
 
   defineOptions({ name: 'ArtBasicBanner' })
 
@@ -89,7 +91,7 @@
     /** 是否启用按钮 */
     show: boolean
     /** 按钮文本 */
-    text: string
+    text?: string
     /** 按钮背景色 */
     color?: string
     /** 按钮文字颜色 */
@@ -151,7 +153,7 @@
     decoration: true,
     buttonConfig: () => ({
       show: true,
-      text: '查看',
+      text: '',
       color: '#fff',
       textColor: '#333',
       radius: '6px'
@@ -170,6 +172,7 @@
   const buttonColor = computed(() => props.buttonConfig?.color ?? '#fff')
   const buttonTextColor = computed(() => props.buttonConfig?.textColor ?? '#333')
   const buttonRadius = computed(() => props.buttonConfig?.radius ?? '6px')
+  const buttonText = computed(() => props.buttonConfig?.text || t('banner.basic.view'))
 
   // 流星数据初始化
   const meteors = ref<Meteor[]>([])

--- a/static/src/components/core/banners/art-card-banner/index.vue
+++ b/static/src/components/core/banners/art-card-banner/index.vue
@@ -19,7 +19,7 @@
           }"
           @click="handleCancel"
         >
-          {{ cancelButton?.text }}
+          {{ cancelButtonText }}
         </div>
         <div
           v-if="button?.show"
@@ -27,7 +27,7 @@
           :style="{ backgroundColor: button?.color, color: button?.textColor }"
           @click="handleClick"
         >
-          {{ button?.text }}
+          {{ buttonText }}
         </div>
       </div>
     </div>
@@ -36,9 +36,12 @@
 
 <script setup lang="ts">
   // 导入默认图标
+  import { computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
   import defaultIcon from '@imgs/3d/icon1.webp'
 
   defineOptions({ name: 'ArtCardBanner' })
+  const { t } = useI18n()
 
   // 定义卡片横幅组件的属性接口
   interface CardBannerProps {
@@ -75,7 +78,7 @@
   }
 
   // 定义组件属性默认值
-  withDefaults(defineProps<CardBannerProps>(), {
+  const props = withDefaults(defineProps<CardBannerProps>(), {
     height: '24rem',
     image: defaultIcon,
     title: '',
@@ -83,14 +86,14 @@
     // 主按钮默认配置
     button: () => ({
       show: true,
-      text: '查看详情',
+      text: '',
       color: 'var(--theme-color)',
       textColor: '#fff'
     }),
     // 取消按钮默认配置
     cancelButton: () => ({
       show: false,
-      text: '取消',
+      text: '',
       color: '#f5f5f5',
       textColor: '#666'
     })
@@ -106,6 +109,9 @@
   const handleClick = () => {
     emit('click')
   }
+
+  const buttonText = computed(() => props.button?.text || t('banner.card.viewDetails'))
+  const cancelButtonText = computed(() => props.cancelButton?.text || t('common.cancel'))
 
   // 取消按钮点击处理函数
   const handleCancel = () => {

--- a/static/src/components/core/cards/art-data-list-card/index.vue
+++ b/static/src/components/core/cards/art-data-list-card/index.vue
@@ -22,8 +22,9 @@
       v-if="showMoreButton"
       v-ripple
       @click="handleMore"
-      >查看更多</ElButton
     >
+      {{ $t('cards.dataList.showMore') }}
+    </ElButton>
   </div>
 </template>
 

--- a/static/src/components/core/cards/art-image-card/index.vue
+++ b/static/src/components/core/cards/art-image-card/index.vue
@@ -19,7 +19,7 @@
           class="absolute right-3.5 bottom-3.5 py-1 px-2 text-xs bg-g-200 rounded"
           v-if="props.readTime"
         >
-          {{ props.readTime }} 阅读
+          {{ props.readTime }} {{ $t('cards.image.readSuffix') }}
         </div>
       </div>
 

--- a/static/src/components/core/forms/art-drag-verify/index.vue
+++ b/static/src/components/core/forms/art-drag-verify/index.vue
@@ -41,7 +41,10 @@
 </template>
 
 <script setup lang="ts">
+  import { useI18n } from 'vue-i18n'
+
   defineOptions({ name: 'ArtDragVerify' })
+  const { t } = useI18n()
 
   // 事件定义
   const emit = defineEmits(['handlerMove', 'update:value', 'passCallback'])
@@ -85,8 +88,6 @@
     value: false,
     width: '100%',
     height: 40,
-    text: '按住滑块拖动',
-    successText: 'success',
     background: '#eee',
     progressBarBg: '#1385FF',
     completedBg: '#57D187',
@@ -225,7 +226,9 @@
 
   // 显示消息计算属性
   const message = computed(() => {
-    return props.value ? props.successText : props.text
+    return props.value
+      ? (props.successText ?? t('dragVerify.successText'))
+      : (props.text ?? t('dragVerify.text'))
   })
 
   /**

--- a/static/src/components/core/forms/art-excel-export/index.vue
+++ b/static/src/components/core/forms/art-excel-export/index.vue
@@ -12,9 +12,9 @@
       <ElIcon class="is-loading">
         <Loading />
       </ElIcon>
-      {{ loadingText }}
+      {{ resolvedLoadingText }}
     </template>
-    <slot>{{ buttonText }}</slot>
+    <slot>{{ resolvedButtonText }}</slot>
   </ElButton>
 </template>
 
@@ -22,6 +22,7 @@
   import ExcelJS from 'exceljs'
   import FileSaver from 'file-saver'
   import { ref, computed, nextTick } from 'vue'
+  import { useI18n } from 'vue-i18n'
   import { Loading } from '@element-plus/icons-vue'
   import type { ButtonType } from 'element-plus'
   import { useThrottleFn } from '@vueuse/core'
@@ -96,10 +97,7 @@
     type: 'primary',
     size: 'default',
     disabled: false,
-    buttonText: '导出 Excel',
-    loadingText: '导出中...',
     autoIndex: false,
-    indexColumnTitle: '序号',
     columns: () => ({}),
     headers: () => ({}),
     maxRows: 100000,
@@ -127,7 +125,13 @@
     }
   }
 
+  const { t, locale } = useI18n()
   const isExporting = ref(false)
+  const resolvedButtonText = computed(() => props.buttonText ?? t('excelExport.buttonText'))
+  const resolvedLoadingText = computed(() => props.loadingText ?? t('excelExport.loadingText'))
+  const resolvedIndexColumnTitle = computed(
+    () => props.indexColumnTitle ?? t('excelExport.indexColumnTitle')
+  )
 
   /** 是否有数据可导出 */
   const hasData = computed(() => Array.isArray(props.data) && props.data.length > 0)
@@ -135,18 +139,22 @@
   /** 验证导出数据 */
   const validateData = (data: ExportData[]): void => {
     if (!Array.isArray(data)) {
-      throw new ExportError('数据必须是数组格式', 'INVALID_DATA_TYPE')
+      throw new ExportError(t('excelExport.invalidDataType'), 'INVALID_DATA_TYPE')
     }
 
     if (data.length === 0) {
-      throw new ExportError('没有可导出的数据', 'NO_DATA')
+      throw new ExportError(t('excelExport.noData'), 'NO_DATA')
     }
 
     if (data.length > props.maxRows) {
-      throw new ExportError(`数据行数超过限制（${props.maxRows}行）`, 'EXCEED_MAX_ROWS', {
-        currentRows: data.length,
-        maxRows: props.maxRows
-      })
+      throw new ExportError(
+        t('excelExport.exceedMaxRows', { maxRows: props.maxRows }),
+        'EXCEED_MAX_ROWS',
+        {
+          currentRows: data.length,
+          maxRows: props.maxRows
+        }
+      )
     }
   }
 
@@ -169,11 +177,11 @@
     }
 
     if (value instanceof Date) {
-      return value.toLocaleDateString('zh-CN')
+      return value.toLocaleDateString(locale.value === 'zh' ? 'zh-CN' : 'en-US')
     }
 
     if (typeof value === 'boolean') {
-      return value ? '是' : '否'
+      return value ? t('excelExport.booleanTrue') : t('excelExport.booleanFalse')
     }
 
     return String(value)
@@ -186,7 +194,7 @@
 
       // 添加序号列
       if (props.autoIndex) {
-        processedItem[props.indexColumnTitle] = String(index + 1)
+        processedItem[resolvedIndexColumnTitle.value] = String(index + 1)
       }
 
       // 处理数据列
@@ -305,7 +313,11 @@
 
       return Promise.resolve()
     } catch (error) {
-      throw new ExportError(`Excel 导出失败: ${(error as Error).message}`, 'EXPORT_FAILED', error)
+      throw new ExportError(
+        t('excelExport.exportFailed', { message: (error as Error).message }),
+        'EXPORT_FAILED',
+        error
+      )
     }
   }
 
@@ -331,7 +343,7 @@
       // 显示成功消息
       if (props.showSuccessMessage) {
         ElMessage.success({
-          message: `成功导出 ${props.data.length} 条数据`,
+          message: t('excelExport.successMessage', { count: props.data.length }),
           duration: 3000
         })
       }
@@ -339,7 +351,11 @@
       const exportError =
         error instanceof ExportError
           ? error
-          : new ExportError(`导出失败: ${(error as Error).message}`, 'UNKNOWN_ERROR', error)
+          : new ExportError(
+              t('excelExport.unknownFailed', { message: (error as Error).message }),
+              'UNKNOWN_ERROR',
+              error
+            )
 
       // 触发错误事件
       emit('export-error', exportError)
@@ -352,7 +368,7 @@
         })
       }
 
-      console.error('Excel 导出错误:', exportError)
+      console.error(t('excelExport.consoleError'), exportError)
     } finally {
       isExporting.value = false
       emit('export-progress', 0)

--- a/static/src/components/core/forms/art-wang-editor/index.vue
+++ b/static/src/components/core/forms/art-wang-editor/index.vue
@@ -24,6 +24,7 @@
   import { useUserStore } from '@/store/modules/user'
   import EmojiText from '@/utils/ui/emojo'
   import { IDomEditor, IToolbarConfig, IEditorConfig } from '@wangeditor/editor'
+  import { useI18n } from 'vue-i18n'
 
   defineOptions({ name: 'ArtWangEditor' })
 
@@ -52,7 +53,6 @@
   const props = withDefaults(defineProps<Props>(), {
     height: '500px',
     mode: 'default',
-    placeholder: '请输入内容...',
     excludeKeys: () => ['fontFamily']
   })
 
@@ -61,6 +61,7 @@
   // 编辑器实例
   const editorRef = shallowRef<IDomEditor>()
   const userStore = useUserStore()
+  const { t } = useI18n()
 
   // 常量配置
   const DEFAULT_UPLOAD_CONFIG = {
@@ -105,8 +106,8 @@
   })
 
   // 编辑器配置
-  const editorConfig: Partial<IEditorConfig> = {
-    placeholder: props.placeholder,
+  const editorConfig = computed<Partial<IEditorConfig>>(() => ({
+    placeholder: props.placeholder || t('common.editorPlaceholder'),
     MENU_CONF: {
       uploadImage: {
         fieldName: mergedUploadConfig.value.fieldName,
@@ -118,15 +119,15 @@
           Authorization: userStore.accessToken
         },
         onSuccess() {
-          ElMessage.success(`图片上传成功 ${EmojiText[200]}`)
+          ElMessage.success(t('common.imageUploadSuccess', { emoji: EmojiText[200] }))
         },
-        onError(file: File, err: any, res: any) {
+        onError(_file: File, err: unknown, res: unknown) {
           console.error('图片上传失败:', err, res)
-          ElMessage.error(`图片上传失败 ${EmojiText[500]}`)
+          ElMessage.error(t('common.imageUploadFailed', { emoji: EmojiText[500] }))
         }
       }
     }
-  }
+  }))
 
   // 编辑器创建回调
   const onCreateEditor = (editor: IDomEditor) => {

--- a/static/src/components/core/layouts/art-chat-window/index.vue
+++ b/static/src/components/core/layouts/art-chat-window/index.vue
@@ -10,7 +10,9 @@
               class="h-2 w-2 rounded-full"
               :class="isOnline ? 'bg-success/100' : 'bg-danger/100'"
             ></div>
-            <span class="text-xs text-g-600">{{ isOnline ? '在线' : '离线' }}</span>
+            <span class="text-xs text-g-600">{{
+              isOnline ? $t('chatWindow.status.online') : $t('chatWindow.status.offline')
+            }}</span>
           </div>
         </div>
         <div>
@@ -63,7 +65,7 @@
             v-model="messageText"
             type="textarea"
             :rows="3"
-            placeholder="输入消息"
+            :placeholder="$t('chatWindow.inputPlaceholder')"
             resize="none"
             @keyup.enter.prevent="sendMessage"
           >
@@ -71,7 +73,9 @@
               <div class="flex gap-2 py-2">
                 <ElButton :icon="Paperclip" circle plain />
                 <ElButton :icon="Picture" circle plain />
-                <ElButton type="primary" @click="sendMessage" v-ripple>发送</ElButton>
+                <ElButton type="primary" @click="sendMessage" v-ripple>{{
+                  $t('chatWindow.send')
+                }}</ElButton>
               </div>
             </template>
           </ElInput>
@@ -80,7 +84,9 @@
               <ArtSvgIcon icon="ri:image-line" class="mr-5 c-p text-g-600 text-lg" />
               <ArtSvgIcon icon="ri:emotion-happy-line" class="mr-5 c-p text-g-600 text-lg" />
             </div>
-            <ElButton type="primary" @click="sendMessage" v-ripple class="min-w-20">发送</ElButton>
+            <ElButton type="primary" @click="sendMessage" v-ripple class="min-w-20">{{
+              $t('chatWindow.send')
+            }}</ElButton>
           </div>
         </div>
       </div>
@@ -90,12 +96,14 @@
 
 <script setup lang="ts">
   import { Picture, Paperclip, Close } from '@element-plus/icons-vue'
+  import { useI18n } from 'vue-i18n'
   import { mittBus } from '@/utils/sys'
   import { formatTime } from '@utils/common'
   import meAvatar from '@/assets/images/avatar/avatar5.webp'
   import aiAvatar from '@/assets/images/avatar/avatar10.webp'
 
   defineOptions({ name: 'ArtChatWindow' })
+  const { t } = useI18n()
 
   // 类型定义
   interface ChatMessage {
@@ -135,7 +143,7 @@
     {
       id: 1,
       sender: BOT_NAME,
-      content: '你好！我是你的AI助手，有什么我可以帮你的吗？',
+      content: t('chatWindow.messages.assistantGreeting'),
       time: buildMockTime(0),
       isMe: false,
       avatar: aiAvatar
@@ -143,7 +151,7 @@
     {
       id: 2,
       sender: USER_NAME,
-      content: '我想了解一下系统的使用方法。',
+      content: t('chatWindow.messages.userUsageQuestion'),
       time: buildMockTime(1),
       isMe: true,
       avatar: meAvatar
@@ -151,7 +159,7 @@
     {
       id: 3,
       sender: BOT_NAME,
-      content: '好的，我来为您介绍系统的主要功能。首先，您可以通过左侧菜单访问不同的功能模块...',
+      content: t('chatWindow.messages.assistantUsageIntro'),
       time: buildMockTime(2),
       isMe: false,
       avatar: aiAvatar
@@ -159,7 +167,7 @@
     {
       id: 4,
       sender: USER_NAME,
-      content: '听起来很不错，能具体讲讲数据分析部分吗？',
+      content: t('chatWindow.messages.userAnalyticsQuestion'),
       time: buildMockTime(5),
       isMe: true,
       avatar: meAvatar
@@ -167,7 +175,7 @@
     {
       id: 5,
       sender: BOT_NAME,
-      content: '当然可以。数据分析模块可以帮助您实时监控关键指标，并生成详细的报表...',
+      content: t('chatWindow.messages.assistantAnalyticsIntro'),
       time: buildMockTime(6),
       isMe: false,
       avatar: aiAvatar
@@ -175,7 +183,7 @@
     {
       id: 6,
       sender: USER_NAME,
-      content: '太好了，那我如何开始使用呢？',
+      content: t('chatWindow.messages.userStartQuestion'),
       time: buildMockTime(8),
       isMe: true,
       avatar: meAvatar
@@ -183,7 +191,7 @@
     {
       id: 7,
       sender: BOT_NAME,
-      content: '您可以先创建一个项目，然后在项目中添加相关的数据源，系统会自动进行分析。',
+      content: t('chatWindow.messages.assistantStartIntro'),
       time: buildMockTime(9),
       isMe: false,
       avatar: aiAvatar
@@ -191,7 +199,7 @@
     {
       id: 8,
       sender: USER_NAME,
-      content: '明白了，谢谢你的帮助！',
+      content: t('chatWindow.messages.userThanks'),
       time: buildMockTime(10),
       isMe: true,
       avatar: meAvatar
@@ -199,7 +207,7 @@
     {
       id: 9,
       sender: BOT_NAME,
-      content: '不客气，有任何问题随时联系我。',
+      content: t('chatWindow.messages.assistantClose'),
       time: buildMockTime(11),
       isMe: false,
       avatar: aiAvatar

--- a/static/src/components/core/layouts/art-header-bar/index.vue
+++ b/static/src/components/core/layouts/art-header-bar/index.vue
@@ -124,7 +124,7 @@
   import { themeAnimation } from '@/utils/ui/animation'
   import { useCommon } from '@/hooks/core/useCommon'
   import { useHeaderBar } from '@/hooks/core/useHeaderBar'
-  import { fetchUnreadCount } from '@/api/notification'
+  import { useNotificationApi } from '@/hooks/core/useNotificationApi'
   import ArtUserMenu from './widget/ArtUserMenu.vue'
 
   defineOptions({ name: 'ArtHeaderBar' })
@@ -132,6 +132,7 @@
   const router = useRouter()
   const { locale } = useI18n()
   const { width } = useWindowSize()
+  const { fetchUnreadCount } = useNotificationApi()
 
   const settingStore = useSettingStore()
   const userStore = useUserStore()

--- a/static/src/components/core/layouts/art-notification/index.vue
+++ b/static/src/components/core/layouts/art-notification/index.vue
@@ -23,7 +23,7 @@
       <span class="text-[13px] text-g-700">
         {{ $t('notice.bar[0]') }} ({{ unreadCount }})
         <span v-if="unreadCount > 0" class="ml-1 text-xs text-danger"
-          >{{ unreadCount }} {{ $t('notice.text[1]') || '未读' }}</span
+          >{{ unreadCount }} {{ $t('notice.text[1]') }}</span
         >
       </span>
     </div>
@@ -33,7 +33,7 @@
         <!-- 加载状态 -->
         <div v-if="loading" class="relative top-25 h-full text-g-500 text-center !bg-transparent">
           <ArtSvgIcon icon="ri:loader-4-line" class="text-3xl animate-spin" />
-          <p class="mt-3.5 text-xs !bg-transparent">{{ $t('notice.text[2]') || '加载中...' }}</p>
+          <p class="mt-3.5 text-xs !bg-transparent">{{ $t('notice.text[2]') }}</p>
         </div>
 
         <!-- 通知列表 -->
@@ -76,7 +76,7 @@
 
       <div class="relative box-border w-full px-3.5 flex gap-2">
         <ElButton v-if="hasMore" class="flex-1 mt-3" @click="loadMore" v-ripple>
-          {{ $t('notice.viewAll') || '加载更多' }}
+          {{ $t('notice.viewAll') }}
         </ElButton>
       </div>
     </div>
@@ -87,8 +87,8 @@
 
 <script setup lang="ts">
   import { ref, watch, onMounted } from 'vue'
-  import { fetchNotifications, markAsRead, markAllAsRead } from '@/api/notification'
   import { formatTime } from '@utils/common'
+  import { useNotificationApi } from '@/hooks/core/useNotificationApi'
 
   defineOptions({ name: 'ArtNotification' })
 
@@ -109,6 +109,7 @@
   const show = ref(false)
   const visible = ref(false)
   const loading = ref(false)
+  const { fetchNotifications, markAsRead, markAllAsRead } = useNotificationApi()
 
   // 通知数据
   const notificationList = ref<Api.Notification.NotificationItem[]>([])

--- a/static/src/components/core/layouts/art-screen-lock/index.vue
+++ b/static/src/components/core/layouts/art-screen-lock/index.vue
@@ -8,12 +8,16 @@
     >
       <div class="p-5 text-center select-none">
         <div class="mb-7.5 text-5xl">🔒</div>
-        <h1 class="m-0 mb-5 text-3xl font-semibold text-danger">系统已锁定</h1>
+        <h1 class="m-0 mb-5 text-3xl font-semibold text-danger">
+          {{ $t('lockScreen.devTools.title') }}
+        </h1>
         <p class="max-w-125 m-0 text-lg leading-relaxed text-white">
-          检测到开发者工具已打开<br />
-          为了系统安全，请关闭开发者工具后继续使用
+          {{ $t('lockScreen.devTools.detected') }}<br />
+          {{ $t('lockScreen.devTools.instructions') }}
         </p>
-        <div class="mt-7.5 text-sm text-gray-400">Security Lock Activated</div>
+        <div class="mt-7.5 text-sm text-gray-400">
+          {{ $t('lockScreen.devTools.activated') }}
+        </div>
       </div>
     </div>
 
@@ -21,7 +25,11 @@
     <div v-if="!isLock">
       <ElDialog v-model="visible" :width="370" :show-close="false" @open="handleDialogOpen">
         <div class="flex-c flex-col">
-          <img class="w-16 h-16 rounded-full" src="@imgs/user/avatar.webp" alt="用户头像" />
+          <img
+            class="w-16 h-16 rounded-full"
+            src="@imgs/user/avatar.webp"
+            :alt="$t('lockScreen.userAvatarAlt')"
+          />
           <div class="mt-7.5 mb-3.5 text-base font-medium">{{ userInfo.userName }}</div>
           <ElForm
             ref="formRef"
@@ -59,7 +67,11 @@
     <!-- 解锁界面 -->
     <div v-else class="unlock-content">
       <div class="flex-c flex-col w-80">
-        <img class="w-16 h-16 mt-5 rounded-full" src="@imgs/user/avatar.webp" alt="用户头像" />
+        <img
+          class="w-16 h-16 mt-5 rounded-full"
+          src="@imgs/user/avatar.webp"
+          :alt="$t('lockScreen.userAvatarAlt')"
+        />
         <div class="mt-3 mb-3.5 text-base font-medium">
           {{ userInfo.userName }}
         </div>
@@ -347,7 +359,7 @@
         visible.value = false
         formData.password = ''
       } else {
-        console.error('表单验证失败:', fields)
+        console.error(t('lockScreen.validationFailedLog'), fields)
       }
     })
   }
@@ -367,7 +379,7 @@
             visible.value = false
             showDevToolsWarning.value = false
           } catch (error) {
-            console.error('更新store失败:', error)
+            console.error(t('lockScreen.storeUpdateFailedLog'), error)
           }
         } else {
           // 触发抖动动画
@@ -382,7 +394,7 @@
           unlockForm.password = ''
         }
       } else {
-        console.error('表单验证失败:', fields)
+        console.error(t('lockScreen.validationFailedLog'), fields)
       }
     })
   }

--- a/static/src/components/core/media/art-cutter-img/index.vue
+++ b/static/src/components/core/media/art-cutter-img/index.vue
@@ -14,10 +14,10 @@
         class="img-cutter"
       >
         <template #choose>
-          <ElButton type="primary" plain v-ripple>选择图片</ElButton>
+          <ElButton type="primary" plain v-ripple>{{ $t('imageCutter.chooseImage') }}</ElButton>
         </template>
         <template #cancel>
-          <ElButton type="danger" plain v-ripple>清除</ElButton>
+          <ElButton type="danger" plain v-ripple>{{ $t('imageCutter.clear') }}</ElButton>
         </template>
         <template #confirm>
           <!-- <ElButton type="primary" style="margin-left: 10px">确定</ElButton> -->
@@ -35,19 +35,26 @@
           height: `${cutterProps.cutHeight}px`
         }"
       >
-        <img class="preview-img" :src="temImgPath" alt="预览图" v-if="temImgPath" />
+        <img
+          class="preview-img"
+          :src="temImgPath"
+          :alt="$t('imageCutter.previewAlt')"
+          v-if="temImgPath"
+        />
       </div>
-      <ElButton class="download-btn" @click="downloadImg" :disabled="!temImgPath" v-ripple
-        >下载图片</ElButton
-      >
+      <ElButton class="download-btn" @click="downloadImg" :disabled="!temImgPath" v-ripple>
+        {{ $t('imageCutter.downloadImage') }}
+      </ElButton>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
   import ImgCutter from 'vue-img-cutter'
+  import { useI18n } from 'vue-i18n'
 
   defineOptions({ name: 'ArtCutterImg' })
+  const { t } = useI18n()
 
   interface CutterProps {
     // 基础配置
@@ -186,12 +193,12 @@
       try {
         await preloadImage(props.imgUrl)
         imgCutterModal.value?.handleOpen({
-          name: '封面图片',
+          name: t('imageCutter.defaultFileName'),
           src: props.imgUrl
         })
       } catch (error) {
         emit('error', error)
-        console.error('图片加载失败:', error)
+        console.error(t('imageCutter.loadFailedLog'), error)
       }
     }
   }
@@ -243,7 +250,6 @@
 
   // 下载图片
   function downloadImg() {
-    console.log('下载图片')
     const a = document.createElement('a')
     a.href = temImgPath.value
     a.download = 'image.png'

--- a/static/src/components/core/tables/art-table/index.vue
+++ b/static/src/components/core/tables/art-table/index.vue
@@ -57,7 +57,7 @@
 
       <template #empty>
         <div v-if="loading"></div>
-        <ElEmpty v-else :description="emptyText" :image-size="120" />
+        <ElEmpty v-else :description="resolvedEmptyText" :image-size="120" />
       </template>
     </ElTable>
 
@@ -82,6 +82,7 @@
 
 <script setup lang="ts">
   import { ref, computed, nextTick, watchEffect } from 'vue'
+  import { useI18n } from 'vue-i18n'
   import type { ElTable, TableProps } from 'element-plus'
   import { storeToRefs } from 'pinia'
   import { ColumnOption } from '@/types'
@@ -103,6 +104,7 @@
   const paginationRef = ref<HTMLElement>()
   const tableHeaderRef = ref<HTMLElement>()
   const tableStore = useTableStore()
+  const { t } = useI18n()
   const { isBorder, isZebra, tableSize, isFullScreen, isHeaderBackground } = storeToRefs(tableStore)
 
   /** 分页配置接口 */
@@ -146,9 +148,9 @@
     border: undefined,
     size: undefined,
     emptyHeight: '100%',
-    emptyText: '暂无数据',
     showTableHeader: true
   })
+  const resolvedEmptyText = computed(() => props.emptyText ?? t('common.noData'))
 
   const LAYOUT = {
     MOBILE: 'prev, pager, next, sizes, jumper, total',

--- a/static/src/components/core/user-facing-text.test.ts
+++ b/static/src/components/core/user-facing-text.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const files = [
+  new URL('./banners/art-basic-banner/index.vue', import.meta.url),
+  new URL('./banners/art-card-banner/index.vue', import.meta.url),
+  new URL('./cards/art-data-list-card/index.vue', import.meta.url),
+  new URL('./cards/art-image-card/index.vue', import.meta.url),
+  new URL('./forms/art-excel-export/index.vue', import.meta.url),
+  new URL('./forms/art-drag-verify/index.vue', import.meta.url),
+  new URL('./layouts/art-chat-window/index.vue', import.meta.url),
+  new URL('./layouts/art-screen-lock/index.vue', import.meta.url),
+  new URL('./media/art-cutter-img/index.vue', import.meta.url),
+  new URL('./tables/art-table/index.vue', import.meta.url),
+  new URL('../../directives/business/highlight.ts', import.meta.url)
+]
+
+const templateAttributePattern = /(?:label|placeholder|title|alt)="[^"]*[\u4e00-\u9fff][^"]*"/g
+const templateTextPattern = />[^<]*[\u4e00-\u9fff][^<]*</g
+const scriptStringPattern = /['"][^'"\n]*[\u4e00-\u9fff][^'"\n]*['"]/g
+
+function stripComments(source: string) {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+}
+
+test('core shared UI keeps Chinese user-facing text in locale files', () => {
+  const matches = files.flatMap((file) => {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const template = source.match(/<template>([\s\S]*?)<\/template>/)?.[1] ?? ''
+    const script = source.match(/<script[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? source
+
+    return [
+      ...(template.match(templateAttributePattern) ?? []),
+      ...(template.match(templateTextPattern) ?? []),
+      ...(script.match(scriptStringPattern) ?? [])
+    ].map((match) => ({ file: file.pathname, match }))
+  })
+
+  assert.deepEqual(matches, [])
+})

--- a/static/src/directives/business/highlight.ts
+++ b/static/src/directives/business/highlight.ts
@@ -43,6 +43,8 @@
 
 import { App, Directive } from 'vue'
 import hljs from 'highlight.js'
+import { ElMessage } from 'element-plus'
+import { $t } from '@/locales'
 
 // 高亮代码
 function highlightCode(block: HTMLElement) {
@@ -70,7 +72,7 @@ function addCopyButton(block: HTMLElement) {
     // 过滤掉行号，只复制代码内容
     const codeContent = block.innerText.replace(/^\d+\s+/gm, '')
     navigator.clipboard.writeText(codeContent).then(() => {
-      ElMessage.success('复制成功')
+      ElMessage.success($t('highlight.copySuccess'))
     })
   }
 
@@ -117,7 +119,7 @@ function processBlock(block: HTMLElement) {
     addCopyButton(block)
     markBlockAsProcessed(block)
   } catch (error) {
-    console.warn('处理代码块时出错:', error)
+    console.warn($t('highlight.processError'), error)
   }
 }
 

--- a/static/src/hooks/core/useNotificationApi.ts
+++ b/static/src/hooks/core/useNotificationApi.ts
@@ -1,0 +1,10 @@
+import { fetchNotifications, fetchUnreadCount, markAllAsRead, markAsRead } from '@/api/notification'
+
+export function useNotificationApi() {
+  return {
+    fetchNotifications,
+    fetchUnreadCount,
+    markAllAsRead,
+    markAsRead
+  }
+}

--- a/static/src/hooks/core/useSdeSearch.ts
+++ b/static/src/hooks/core/useSdeSearch.ts
@@ -1,0 +1,5 @@
+import { fuzzySearch } from '@/api/sde'
+
+export function useSdeSearch() {
+  return { fuzzySearch }
+}

--- a/static/src/hooks/core/useTable.ts
+++ b/static/src/hooks/core/useTable.ts
@@ -35,6 +35,7 @@ import {
   createErrorHandler
 } from '../../utils/table/tableUtils'
 import { tableConfig } from '../../utils/table/tableConfig'
+import { $t } from '@/locales'
 
 // 类型推导工具类型
 type InferApiParams<T> = T extends (params: infer P) => any ? P : never
@@ -242,7 +243,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
   })
 
   // 错误处理函数
-  const handleError = createErrorHandler(onError, enableLog)
+  const handleError = createErrorHandler(onError, enableLog, $t('table.unknownError'))
 
   // 清理缓存，根据不同的业务场景选择性地清理缓存
   const clearCache = (strategy: CacheInvalidationStrategy, context?: string): void => {
@@ -346,7 +347,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
 
       // 检查请求是否被取消
       if (currentController.signal.aborted) {
-        throw new Error('请求已取消')
+        throw new Error($t('table.requestCancelled'))
       }
 
       // 使用响应适配器转换为标准格式
@@ -391,7 +392,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
 
       return standardResponse
     } catch (err) {
-      if (err instanceof Error && err.message === '请求已取消') {
+      if (err instanceof Error && err.message === $t('table.requestCancelled')) {
         // 请求被取消，回到 idle 状态
         loadingState.value = 'idle'
         return { list: [], total: 0, current: 1, size: 10 }
@@ -400,7 +401,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
       // 状态机：请求失败，进入 error 状态
       loadingState.value = 'error'
       data.value = []
-      const tableError = handleError(err, '获取表格数据失败')
+      const tableError = handleError(err, $t('table.fetchFailed'))
       throw tableError
     } finally {
       // 只有当前控制器是活跃的才清空
@@ -426,7 +427,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
     ;(searchParams as Record<string, unknown>)[pageKey] = 1
 
     // 搜索时清空当前搜索条件的缓存，确保获取最新数据
-    clearCache(CacheInvalidationStrategy.CLEAR_CURRENT, '搜索数据')
+    clearCache(CacheInvalidationStrategy.CLEAR_CURRENT, $t('table.searchCache'))
 
     try {
       return await fetchData(params, false) // 搜索时不使用缓存
@@ -467,7 +468,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
     error.value = null
 
     // 清空缓存
-    clearCache(CacheInvalidationStrategy.CLEAR_ALL, '重置搜索')
+    clearCache(CacheInvalidationStrategy.CLEAR_ALL, $t('table.resetSearchCache'))
 
     // 重新获取数据
     await getData()

--- a/static/src/hooks/srp/useKillmailDetail.ts
+++ b/static/src/hooks/srp/useKillmailDetail.ts
@@ -1,0 +1,5 @@
+import { fetchKillmailDetail } from '@/api/srp'
+
+export function useKillmailDetail() {
+  return { fetchKillmailDetail }
+}

--- a/static/src/hooks/srp/useSrpLocalization.test.ts
+++ b/static/src/hooks/srp/useSrpLocalization.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const files = [
+  new URL('./useSrpManage.ts', import.meta.url),
+  new URL('./useSrpWorkflow.ts', import.meta.url)
+]
+
+function stripComments(source: string) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+}
+
+test('srp hooks keep Chinese user-facing output in locale files', () => {
+  const matches = files.flatMap((file) => {
+    const source = stripComments(readFileSync(file, 'utf8'))
+
+    return (source.match(/['"][^'"\n]*[\u4e00-\u9fff][^'"\n]*['"]/g) ?? []).map((match) => ({
+      file: file.pathname,
+      match
+    }))
+  })
+
+  assert.deepEqual(matches, [])
+})

--- a/static/src/hooks/srp/useSrpManage.ts
+++ b/static/src/hooks/srp/useSrpManage.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, computed, watch, onMounted } from 'vue'
+import { ref, reactive, computed, watch, onMounted, type Component } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useTable } from '@/hooks/core/useTable'
 import { useNameResolver } from '@/hooks'
@@ -8,8 +8,6 @@ import { fetchFleetList } from '@/api/fleet'
 import { fetchApplicationList } from '@/api/srp'
 import { formatIskSmart, formatTime } from '@utils/common'
 import { ElTag, ElTooltip, ElLink } from 'element-plus'
-import ArtButtonTable from '@/components/core/forms/art-button-table/index.vue'
-import ArtCopyButton from '@/components/core/forms/art-copy-button/index.vue'
 
 type SrpApp = Api.Srp.Application
 type TagType = 'primary' | 'success' | 'warning' | 'info' | 'danger'
@@ -18,8 +16,13 @@ export function useSrpManage(callbacks: {
   openReviewDialog: (row: SrpApp, action: 'approve' | 'reject') => void
   handlePayoutAction: (row: SrpApp) => void
   openKmPreview: (row: SrpApp) => void
+  components: {
+    ArtButtonTable: Component
+    ArtCopyButton: Component
+  }
 }) {
   const { t } = useI18n()
+  const { ArtButtonTable, ArtCopyButton } = callbacks.components
   const { getName, resolve: resolveNames } = useNameResolver()
   const { createEnterSearchHandler } = useEnterSearch()
   const userStore = useUserStore()
@@ -373,24 +376,24 @@ export function useSrpManage(callbacks: {
   }
 
   // ─── Export ───
-  const manageExportHeaders = {
-    character_name: '人物',
-    ship_name: '舰船',
-    solar_system: '星系',
-    killmail_id: 'KillID',
-    killmail_time: 'KM时间',
-    corporation: '军团',
-    alliance: '联盟',
-    fleet_title: '关联舰队',
-    fleet_fc_name: 'FC',
-    note: '备注',
-    recommended_amount: '推荐金额',
-    final_amount: '最终金额',
-    review_status: '审批状态',
-    review_note: '审批备注',
-    last_actor_nickname: '补损官',
-    payout_status: '发放状态'
-  }
+  const manageExportHeaders = computed(() => ({
+    character_name: t('srp.manage.exportColumns.character'),
+    ship_name: t('srp.manage.exportColumns.ship'),
+    solar_system: t('srp.manage.exportColumns.system'),
+    killmail_id: t('srp.manage.exportColumns.killId'),
+    killmail_time: t('srp.manage.exportColumns.kmTime'),
+    corporation: t('srp.manage.exportColumns.corporation'),
+    alliance: t('srp.manage.exportColumns.alliance'),
+    fleet_title: t('srp.manage.exportColumns.fleet'),
+    fleet_fc_name: t('srp.manage.exportColumns.fc'),
+    note: t('srp.manage.exportColumns.note'),
+    recommended_amount: t('srp.manage.exportColumns.recommendedAmount'),
+    final_amount: t('srp.manage.exportColumns.finalAmount'),
+    review_status: t('srp.manage.exportColumns.reviewStatus'),
+    review_note: t('srp.manage.exportColumns.reviewNote'),
+    last_actor_nickname: t('srp.manage.exportColumns.lastActor'),
+    payout_status: t('srp.manage.exportColumns.payoutStatus')
+  }))
 
   const exportManageData = computed(() =>
     data.value.map((app) => ({

--- a/static/src/hooks/srp/useSrpWorkflow.ts
+++ b/static/src/hooks/srp/useSrpWorkflow.ts
@@ -57,10 +57,6 @@ export function useSrpWorkflow(deps: {
     )
   })
 
-  const DEFAULT_APPROVE_NOTE = '补损由补损官{{mainChracterName}}手动批准，如有问题请Q群联系'
-  const DEFAULT_REJECT_NOTE =
-    '不符合现有补损条例。如有问题请Q群联系{{mainChracterName}}（或游戏内邮件{{mainChracterName}})'
-
   const fillTemplate = (tpl: string) =>
     tpl.replaceAll('{{mainChracterName}}', primaryCharName.value || t('srp.manage.unknownReviewer'))
 
@@ -74,9 +70,9 @@ export function useSrpWorkflow(deps: {
     reviewForm.review_note =
       action === 'approve'
         ? row.review_status === 'submitted'
-          ? fillTemplate(DEFAULT_APPROVE_NOTE)
+          ? fillTemplate(t('srp.manage.defaultApproveNote'))
           : row.review_note || ''
-        : fillTemplate(DEFAULT_REJECT_NOTE)
+        : fillTemplate(t('srp.manage.defaultRejectNote'))
     reviewForm.final_amount = action === 'approve' ? row.final_amount : 0
     reviewDialogVisible.value = true
   }

--- a/static/src/locales/langs/en.json
+++ b/static/src/locales/langs/en.json
@@ -21,6 +21,64 @@
       "logout": "Log out"
     }
   },
+  "userCenter": {
+    "profile": {
+      "bio": "Focused on user experience and visual design",
+      "role": "Interaction Specialist",
+      "location": "Shenzhen, Guangdong",
+      "organization": "ByteDance - Platform UED",
+      "nickname": "Pikachu",
+      "address": "Room 201, Building 101, Xixiang, Bao'an District, Shenzhen",
+      "description": "Art Design Pro is an admin system with strong design and development efficiency."
+    },
+    "sections": {
+      "tags": "Tags",
+      "basicSettings": "Basic Settings",
+      "changePassword": "Change Password"
+    },
+    "fields": {
+      "realName": "Name",
+      "sex": "Gender",
+      "sexPlaceholder": "Select gender",
+      "nickName": "Nickname",
+      "email": "Email",
+      "mobile": "Mobile",
+      "address": "Address",
+      "description": "Profile",
+      "currentPassword": "Current Password",
+      "newPassword": "New Password",
+      "confirmPassword": "Confirm Password"
+    },
+    "validation": {
+      "realNameRequired": "Please enter a name",
+      "nickNameRequired": "Please enter a nickname",
+      "length2To50": "Length must be 2 to 50 characters",
+      "emailRequired": "Please enter an email",
+      "mobileRequired": "Please enter a mobile number",
+      "addressRequired": "Please enter an address",
+      "sexRequired": "Please select a gender"
+    },
+    "sex": {
+      "male": "Male",
+      "female": "Female"
+    },
+    "tags": {
+      "design": "Design-focused",
+      "creative": "Creative",
+      "bold": "Bold",
+      "tall": "Tall",
+      "sichuan": "Sichuan",
+      "inclusive": "Inclusive"
+    },
+    "greetings": {
+      "earlyMorning": "Good morning",
+      "morning": "Good morning",
+      "noon": "Good noon",
+      "afternoon": "Good afternoon",
+      "evening": "Good evening",
+      "lateNight": "It is late. Get some rest."
+    }
+  },
   "common": {
     "tips": "Prompt",
     "cancel": "Cancel",
@@ -43,12 +101,99 @@
     "copy": "Copy",
     "copied": "Copied",
     "copyFailed": "Copy failed",
+    "noData": "No data",
     "millionIsk": "Million ISK",
     "updatedAt": "Updated At",
     "createdAt": "Created At",
     "logOutTips": "Do you want to log out?",
     "search": "Search",
-    "reset": "Reset"
+    "reset": "Reset",
+    "editorPlaceholder": "Enter content...",
+    "imageUploadSuccess": "Image uploaded {emoji}",
+    "imageUploadFailed": "Image upload failed {emoji}"
+  },
+  "excelExport": {
+    "buttonText": "Export Excel",
+    "loadingText": "Exporting...",
+    "indexColumnTitle": "No.",
+    "invalidDataType": "Data must be an array",
+    "noData": "No data to export",
+    "exceedMaxRows": "Row count exceeds the limit ({maxRows} rows)",
+    "booleanTrue": "Yes",
+    "booleanFalse": "No",
+    "exportFailed": "Excel export failed: {message}",
+    "unknownFailed": "Export failed: {message}",
+    "successMessage": "Exported {count} rows",
+    "consoleError": "Excel export error:"
+  },
+  "highlight": {
+    "copySuccess": "Copied",
+    "processError": "Error processing code block:"
+  },
+  "table": {
+    "requestCancelled": "Request cancelled",
+    "fetchFailed": "Failed to load table data",
+    "searchCache": "search data",
+    "resetSearchCache": "reset search",
+    "unknownError": "Unknown error"
+  },
+  "storage": {
+    "invalidLocalData": "Local data looks invalid. Please sign in again to recover."
+  },
+  "color": {
+    "invalidHex": "Invalid hex color value",
+    "invalidRgb": "Invalid RGB color value"
+  },
+  "route": {
+    "menuListFailed": "Failed to load the menu list. Please sign in again."
+  },
+  "chatWindow": {
+    "status": {
+      "online": "Online",
+      "offline": "Offline"
+    },
+    "inputPlaceholder": "Enter a message",
+    "send": "Send",
+    "messages": {
+      "assistantGreeting": "Hello. I am your AI assistant. How can I help?",
+      "userUsageQuestion": "I want to learn how to use the system.",
+      "assistantUsageIntro": "Sure. I will introduce the main system features. You can start from the left menu to access different modules...",
+      "userAnalyticsQuestion": "That sounds useful. Can you explain the analytics section?",
+      "assistantAnalyticsIntro": "Of course. The analytics module helps you monitor key metrics in real time and generate detailed reports...",
+      "userStartQuestion": "Great. How do I get started?",
+      "assistantStartIntro": "You can create a project first, add data sources to it, and the system will analyze them automatically.",
+      "userThanks": "Understood. Thanks for your help.",
+      "assistantClose": "You are welcome. Contact me anytime if you have questions."
+    }
+  },
+  "dragVerify": {
+    "text": "Hold and drag the slider",
+    "successText": "Verified"
+  },
+  "imageCutter": {
+    "chooseImage": "Choose image",
+    "clear": "Clear",
+    "previewAlt": "Preview image",
+    "downloadImage": "Download image",
+    "defaultFileName": "Cover image",
+    "loadFailedLog": "Image load failed:"
+  },
+  "banner": {
+    "basic": {
+      "view": "View",
+      "backgroundAlt": "Background image"
+    },
+    "card": {
+      "viewDetails": "View details"
+    }
+  },
+  "cards": {
+    "dataList": {
+      "showMore": "Show more"
+    },
+    "image": {
+      "readSuffix": "read"
+    }
   },
   "mailAttempt": {
     "sent": "In-game mail accepted.",
@@ -163,7 +308,9 @@
       "Notice"
     ],
     "text": [
-      "No"
+      "No",
+      "Unread",
+      "Loading..."
     ],
     "viewAll": "View all"
   },
@@ -181,6 +328,7 @@
   "console": {
     "alliancePap": "Alliance PAP",
     "internalPap": "Internal PAP",
+    "dashboardLoadFailedLog": "Failed to load dashboard data",
     "papChart": {
       "recentMonths": "Last {count} months",
       "monthLabel": "{year}-{month}",
@@ -224,11 +372,21 @@
     "agreeText": "I agree",
     "privacyPolicy": "Privacy policy",
     "submitBtnText": "Register",
+    "success": "Registration successful",
     "hasAccount": "Already have an account?",
     "toLogin": "To login"
   },
   "lockScreen": {
     "pwdError": "Password error",
+    "userAvatarAlt": "User avatar",
+    "validationFailedLog": "Form validation failed:",
+    "storeUpdateFailedLog": "Failed to update store:",
+    "devTools": {
+      "title": "System locked",
+      "detected": "Developer tools are open",
+      "instructions": "For system security, close developer tools before continuing",
+      "activated": "Security lock activated"
+    },
     "lock": {
       "inputPlaceholder": "Please input lock screen password",
       "btnText": "Lock"
@@ -369,6 +527,28 @@
       "leadership": "Leadership",
       "contributors": "Major Contributors",
       "manage": "Fuxi Hall Management"
+    }
+  },
+  "authActions": {
+    "shop": {
+      "addProduct": "Add Product",
+      "editProduct": "Edit Product",
+      "deleteProduct": "Delete Product",
+      "approveOrder": "Approve Order"
+    },
+    "srp": {
+      "approve": "Approve"
+    },
+    "system": {
+      "deleteUser": "Delete User",
+      "assignRole": "Assign Role",
+      "executeTask": "Execute Task",
+      "updateSchedule": "Update Schedule",
+      "adjustBalance": "Adjust Balance",
+      "viewLog": "View Log",
+      "viewAuditDetail": "View Audit Detail",
+      "editExchangeRate": "Edit Exchange Rate",
+      "manualFetch": "Manual Fetch"
     }
   },
   "fuxiHall": {
@@ -653,11 +833,26 @@
     "noSkillQueue": "No skills in training",
     "noSkillData": "No skill data",
     "skillNotLearned": "Skill book not injected",
+    "esiRefreshButton": "ESI Refresh",
+    "esiRefreshTitle": "ESI Refresh",
+    "esiRefreshConfirmButton": "Refresh",
+    "walletESIRefreshConfirm": "Refresh wallet data for character \"{name}\" from ESI?",
+    "skillESIRefreshConfirm": "Refresh skill data for character \"{name}\" from ESI?",
+    "walletESIRefreshSubmitted": "Wallet ESI refresh task submitted. Refresh later to see the latest data.",
+    "skillESIRefreshSubmitted": "Skill ESI refresh task submitted. Refresh later to see the latest data.",
+    "esiRefreshSubmitFailed": "Failed to submit ESI refresh task",
+    "esiRefreshUnauthorized": "You cannot operate on this character",
+    "esiRefreshCharacterNotFound": "Character not found",
     "totalSPLabel": "Total Skill Points",
     "allSkills": "All Skills",
     "unallocatedSPSuffix": " unallocated skill points.",
     "totalTrainingTime": "Training Time",
     "queuedSPSuffix": " skill points in queue",
+    "trainingComplete": "Complete",
+    "durationDays": "{count}d",
+    "durationHours": "{count}h",
+    "durationMinutes": "{count}m",
+    "durationSeconds": "{count}s",
     "journalIndex": "ID",
     "flyableShips": "Flyable Ships",
     "allRaces": "All Races",
@@ -926,6 +1121,7 @@
     "exampleEvidenceLabel": "Example (provided by admin):",
     "uploadEvidenceBtn": "Choose Image",
     "skillPlanningAlertPrefix": "Go to ",
+    "skillPlanningCheckLink": "Skill Planning - Check Completion",
     "multicharRewardBanner": "Multi-character welfare policy: for per-character welfare with Fuxi Coin payout, the first 3 characters per user receive 100%, characters 4-6 receive 50%, and the rest receive no Fuxi Coin. Exact values depend on admin configuration."
   },
   "welfareApproval": {
@@ -1883,6 +2079,7 @@
         "manualTransfer": "Manual Transfer"
       },
       "exportBtn": "Export Data",
+      "exportSheetName": "SRP Applications",
       "autoApproveBtn": "Auto Approve",
       "batchPayoutBtn": "Batch Payout",
       "approveBtn": "Approve",
@@ -1928,6 +2125,8 @@
       "fuxiPayoutSuccess": "Fuxi Coin SRP issued: {amount} coins",
       "rejectRequired": "A note is required when rejecting",
       "unknownReviewer": "Reviewer",
+      "defaultApproveNote": "SRP manually approved by {{mainChracterName}}. Contact them in QQ group if you have questions.",
+      "defaultRejectNote": "Does not meet the current SRP policy. Contact {{mainChracterName}} in QQ group or by in-game mail if you have questions.",
       "payoutKillId": "KillID",
       "openInfoWindow": "Open Info Window",
       "editBtn": "@:common.edit",
@@ -1957,6 +2156,24 @@
         "payout": "Payout",
         "lastActor": "SRP Officer",
         "action": "Action"
+      },
+      "exportColumns": {
+        "character": "Character",
+        "ship": "Ship",
+        "system": "System",
+        "killId": "KillID",
+        "kmTime": "KM Time",
+        "corporation": "Corporation",
+        "alliance": "Alliance",
+        "fleet": "Fleet",
+        "fc": "FC",
+        "note": "Note",
+        "recommendedAmount": "Recommended Amount",
+        "finalAmount": "Final Amount",
+        "reviewStatus": "Review Status",
+        "reviewNote": "Review Note",
+        "lastActor": "SRP Officer",
+        "payoutStatus": "Payout Status"
       }
     },
     "prices": {
@@ -2698,6 +2915,12 @@
   "webhook": {
     "title": "Webhook Notification Settings",
     "saveSuccess": "Settings saved",
+    "providers": {
+      "discord": "Discord",
+      "feishu": "Feishu",
+      "dingtalk": "DingTalk",
+      "onebot": "OneBot v11 (QQ)"
+    },
     "fields": {
       "enabled": "Enabled",
       "url": "Webhook URL",

--- a/static/src/locales/langs/zh.json
+++ b/static/src/locales/langs/zh.json
@@ -16,6 +16,64 @@
     "requestConfigError": "请求配置错误"
   },
   "topBar": { "user": { "userCenter": "个人中心", "logout": "退出登录" } },
+  "userCenter": {
+    "profile": {
+      "bio": "专注于用户体验跟视觉设计",
+      "role": "交互专家",
+      "location": "广东省深圳市",
+      "organization": "字节跳动－某某平台部－UED",
+      "nickname": "皮卡丘",
+      "address": "广东省深圳市宝安区西乡街道101栋201",
+      "description": "Art Design Pro 是一款兼具设计美学与高效开发的后台系统."
+    },
+    "sections": {
+      "tags": "标签",
+      "basicSettings": "基本设置",
+      "changePassword": "更改密码"
+    },
+    "fields": {
+      "realName": "姓名",
+      "sex": "性别",
+      "sexPlaceholder": "请选择性别",
+      "nickName": "昵称",
+      "email": "邮箱",
+      "mobile": "手机",
+      "address": "地址",
+      "description": "个人介绍",
+      "currentPassword": "当前密码",
+      "newPassword": "新密码",
+      "confirmPassword": "确认新密码"
+    },
+    "validation": {
+      "realNameRequired": "请输入姓名",
+      "nickNameRequired": "请输入昵称",
+      "length2To50": "长度在 2 到 50 个字符",
+      "emailRequired": "请输入邮箱",
+      "mobileRequired": "请输入手机号码",
+      "addressRequired": "请输入地址",
+      "sexRequired": "请选择性别"
+    },
+    "sex": {
+      "male": "男",
+      "female": "女"
+    },
+    "tags": {
+      "design": "专注设计",
+      "creative": "很有想法",
+      "bold": "辣~",
+      "tall": "大长腿",
+      "sichuan": "川妹子",
+      "inclusive": "海纳百川"
+    },
+    "greetings": {
+      "earlyMorning": "早上好",
+      "morning": "上午好",
+      "noon": "中午好",
+      "afternoon": "下午好",
+      "evening": "晚上好",
+      "lateNight": "很晚了，早点睡"
+    }
+  },
   "common": {
     "tips": "提示",
     "cancel": "取消",
@@ -38,12 +96,99 @@
     "copy": "复制",
     "copied": "已复制",
     "copyFailed": "复制失败",
+    "noData": "暂无数据",
     "millionIsk": "百万 ISK",
     "updatedAt": "更新时间",
     "createdAt": "创建时间",
     "logOutTips": "您是否要退出登录?",
     "search": "查询",
-    "reset": "重置"
+    "reset": "重置",
+    "editorPlaceholder": "请输入内容...",
+    "imageUploadSuccess": "图片上传成功 {emoji}",
+    "imageUploadFailed": "图片上传失败 {emoji}"
+  },
+  "excelExport": {
+    "buttonText": "导出 Excel",
+    "loadingText": "导出中...",
+    "indexColumnTitle": "序号",
+    "invalidDataType": "数据必须是数组格式",
+    "noData": "没有可导出的数据",
+    "exceedMaxRows": "数据行数超过限制（{maxRows}行）",
+    "booleanTrue": "是",
+    "booleanFalse": "否",
+    "exportFailed": "Excel 导出失败: {message}",
+    "unknownFailed": "导出失败: {message}",
+    "successMessage": "成功导出 {count} 条数据",
+    "consoleError": "Excel 导出错误:"
+  },
+  "highlight": {
+    "copySuccess": "复制成功",
+    "processError": "处理代码块时出错:"
+  },
+  "table": {
+    "requestCancelled": "请求已取消",
+    "fetchFailed": "获取表格数据失败",
+    "searchCache": "搜索数据",
+    "resetSearchCache": "重置搜索",
+    "unknownError": "未知错误"
+  },
+  "storage": {
+    "invalidLocalData": "系统检测到本地数据异常，请重新登录系统恢复使用！"
+  },
+  "color": {
+    "invalidHex": "输入错误的 hex 颜色值",
+    "invalidRgb": "输入错误的 RGB 颜色值"
+  },
+  "route": {
+    "menuListFailed": "获取菜单列表失败，请重新登录"
+  },
+  "chatWindow": {
+    "status": {
+      "online": "在线",
+      "offline": "离线"
+    },
+    "inputPlaceholder": "输入消息",
+    "send": "发送",
+    "messages": {
+      "assistantGreeting": "你好！我是你的 AI 助手，有什么我可以帮你的吗？",
+      "userUsageQuestion": "我想了解一下系统的使用方法。",
+      "assistantUsageIntro": "好的，我来为您介绍系统的主要功能。首先，您可以通过左侧菜单访问不同的功能模块...",
+      "userAnalyticsQuestion": "听起来很不错，能具体讲讲数据分析部分吗？",
+      "assistantAnalyticsIntro": "当然可以。数据分析模块可以帮助您实时监控关键指标，并生成详细的报表...",
+      "userStartQuestion": "太好了，那我如何开始使用呢？",
+      "assistantStartIntro": "您可以先创建一个项目，然后在项目中添加相关的数据源，系统会自动进行分析。",
+      "userThanks": "明白了，谢谢你的帮助！",
+      "assistantClose": "不客气，有任何问题随时联系我。"
+    }
+  },
+  "dragVerify": {
+    "text": "按住滑块拖动",
+    "successText": "验证通过"
+  },
+  "imageCutter": {
+    "chooseImage": "选择图片",
+    "clear": "清除",
+    "previewAlt": "预览图",
+    "downloadImage": "下载图片",
+    "defaultFileName": "封面图片",
+    "loadFailedLog": "图片加载失败:"
+  },
+  "banner": {
+    "basic": {
+      "view": "查看",
+      "backgroundAlt": "背景图片"
+    },
+    "card": {
+      "viewDetails": "查看详情"
+    }
+  },
+  "cards": {
+    "dataList": {
+      "showMore": "查看更多"
+    },
+    "image": {
+      "readSuffix": "阅读"
+    }
   },
   "mailAttempt": {
     "sent": "游戏内邮件已被 ESI 接受。",
@@ -120,12 +265,13 @@
     "title": "通知",
     "btnRead": "标为已读",
     "bar": ["通知"],
-    "text": ["暂无"],
+    "text": ["暂无", "未读", "加载中..."],
     "viewAll": "查看全部"
   },
   "console": {
     "alliancePap": "联盟 PAP",
     "internalPap": "内部 PAP",
+    "dashboardLoadFailedLog": "加载工作台数据失败",
     "papChart": {
       "recentMonths": "近 {count} 个月",
       "monthLabel": "{year}年{month}月",
@@ -180,11 +326,21 @@
     "agreeText": "我同意",
     "privacyPolicy": "《隐私政策》",
     "submitBtnText": "注册",
+    "success": "注册成功",
     "hasAccount": "已有账号？",
     "toLogin": "去登录"
   },
   "lockScreen": {
     "pwdError": "密码错误",
+    "userAvatarAlt": "用户头像",
+    "validationFailedLog": "表单验证失败:",
+    "storeUpdateFailedLog": "更新 store 失败:",
+    "devTools": {
+      "title": "系统已锁定",
+      "detected": "检测到开发者工具已打开",
+      "instructions": "为了系统安全，请关闭开发者工具后继续使用",
+      "activated": "安全锁定已激活"
+    },
     "lock": { "inputPlaceholder": "请输入锁屏密码", "btnText": "锁定" },
     "unlock": { "inputPlaceholder": "请输入解锁密码", "btnText": "解锁", "backBtnText": "返回登录" }
   },
@@ -312,6 +468,28 @@
       "leadership": "管理层",
       "contributors": "重大贡献成员",
       "manage": "伏羲大厅管理"
+    }
+  },
+  "authActions": {
+    "shop": {
+      "addProduct": "新增商品",
+      "editProduct": "编辑商品",
+      "deleteProduct": "删除商品",
+      "approveOrder": "审批订单"
+    },
+    "srp": {
+      "approve": "审批"
+    },
+    "system": {
+      "deleteUser": "删除用户",
+      "assignRole": "分配职权",
+      "executeTask": "执行任务",
+      "updateSchedule": "修改调度",
+      "adjustBalance": "调整余额",
+      "viewLog": "查看日志",
+      "viewAuditDetail": "查看审计明细",
+      "editExchangeRate": "编辑兑换率",
+      "manualFetch": "手动拉取"
     }
   },
   "fuxiHall": {
@@ -567,6 +745,16 @@
     "journalDescription": "描述",
     "journalReason": "@:common.reason",
     "noJournalData": "暂无钱包流水记录",
+    "esiRefreshButton": "ESI 拉取",
+    "esiRefreshTitle": "ESI 拉取",
+    "esiRefreshConfirmButton": "确认拉取",
+    "walletESIRefreshConfirm": "确认从 ESI 拉取角色「{name}」的钱包数据？",
+    "skillESIRefreshConfirm": "确认从 ESI 拉取角色「{name}」的技能数据？",
+    "walletESIRefreshSubmitted": "钱包数据 ESI 刷新任务已提交，稍后可点击刷新按钮查看最新数据",
+    "skillESIRefreshSubmitted": "技能数据 ESI 刷新任务已提交，稍后可点击刷新按钮查看最新数据",
+    "esiRefreshSubmitFailed": "ESI 刷新任务提交失败",
+    "esiRefreshUnauthorized": "无权操作此角色",
+    "esiRefreshCharacterNotFound": "角色未找到",
     "totalSP": "总技能点",
     "unallocatedSP": "未分配 SP",
     "skillCount": "技能数量",
@@ -588,6 +776,11 @@
     "unallocatedSPSuffix": " 未分配技能点。",
     "totalTrainingTime": "训练时间",
     "queuedSPSuffix": "个技能点排队中",
+    "trainingComplete": "已完成",
+    "durationDays": "{count}天",
+    "durationHours": "{count}小时",
+    "durationMinutes": "{count}分",
+    "durationSeconds": "{count}秒",
     "journalIndex": "ID",
     "flyableShips": "可驾驶舰船",
     "allRaces": "全部种族",
@@ -856,6 +1049,7 @@
     "exampleEvidenceLabel": "示例图片（管理员提供）：",
     "uploadEvidenceBtn": "选择图片",
     "skillPlanningAlertPrefix": "如有技能不达标，可前往",
+    "skillPlanningCheckLink": "技能规划-检查完成度",
     "multicharRewardBanner": "多人物福利发放规则：按人物发放且附带伏羲币的福利，同一用户前 3 个人物获得 100% 伏羲币，第 4-6 个人物获得 50%，其余人物不获得伏羲币。具体数值以管理员配置为准。"
   },
   "welfareApproval": {
@@ -1758,6 +1952,7 @@
       "payoutModeLabel": "发放方式",
       "payoutModes": { "fuxiCoin": "伏羲币补损", "manualTransfer": "手动打钱" },
       "exportBtn": "导出当前数据",
+      "exportSheetName": "补损申请",
       "autoApproveBtn": "自动审批",
       "batchPayoutBtn": "批量发放",
       "approveBtn": "批准",
@@ -1803,6 +1998,8 @@
       "fuxiPayoutSuccess": "伏羲币补损发放成功，已发放 {amount} 伏羲币",
       "rejectRequired": "拒绝时必须填写审批备注",
       "unknownReviewer": "审批人",
+      "defaultApproveNote": "补损由补损官{{mainChracterName}}手动批准，如有问题请Q群联系",
+      "defaultRejectNote": "不符合现有补损条例。如有问题请Q群联系{{mainChracterName}}（或游戏内邮件{{mainChracterName}})",
       "payoutKillId": "KillID",
       "openInfoWindow": "打开人物信息",
       "editBtn": "@:common.edit",
@@ -1832,6 +2029,24 @@
         "payout": "发放",
         "lastActor": "补损官",
         "action": "操作"
+      },
+      "exportColumns": {
+        "character": "人物",
+        "ship": "舰船",
+        "system": "星系",
+        "killId": "KillID",
+        "kmTime": "KM时间",
+        "corporation": "军团",
+        "alliance": "联盟",
+        "fleet": "关联舰队",
+        "fc": "FC",
+        "note": "备注",
+        "recommendedAmount": "推荐金额",
+        "finalAmount": "最终金额",
+        "reviewStatus": "审批状态",
+        "reviewNote": "审批备注",
+        "lastActor": "补损官",
+        "payoutStatus": "发放状态"
       }
     },
     "prices": {
@@ -2423,6 +2638,12 @@
   "webhook": {
     "title": "Webhook 通知设置",
     "saveSuccess": "设置已保存",
+    "providers": {
+      "discord": "Discord",
+      "feishu": "飞书 (Feishu)",
+      "dingtalk": "钉钉 (DingTalk)",
+      "onebot": "OneBot v11 (QQ)"
+    },
     "fields": {
       "enabled": "启用",
       "url": "Webhook URL",

--- a/static/src/router/core/menuAccess.test.ts
+++ b/static/src/router/core/menuAccess.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import type { AppRouteRecord } from '../../types/router'
 import { dashboardRoutes } from '../modules/dashboard'
@@ -43,6 +44,58 @@ const newbroRoutes: AppRouteRecord[] = [
     ]
   }
 ]
+
+const zhMessages = JSON.parse(
+  readFileSync(new URL('../../locales/langs/zh.json', import.meta.url), 'utf8')
+) as Record<string, unknown>
+
+const enMessages = JSON.parse(
+  readFileSync(new URL('../../locales/langs/en.json', import.meta.url), 'utf8')
+) as Record<string, unknown>
+
+function getLocaleValue(messages: Record<string, unknown>, key: string) {
+  return key.split('.').reduce<unknown>((value, part) => {
+    if (!value || typeof value !== 'object') return undefined
+    return (value as Record<string, unknown>)[part]
+  }, messages)
+}
+
+function collectAuthListTitles(routes: AppRouteRecord[], parentPath = '') {
+  const titles: Array<{ path: string; title: string }> = []
+
+  for (const route of routes) {
+    const path = `${parentPath}/${route.path}`.replace(/\/+/g, '/')
+    for (const action of route.meta?.authList ?? []) {
+      titles.push({ path, title: action.title })
+    }
+    if (route.children?.length) {
+      titles.push(...collectAuthListTitles(route.children, path))
+    }
+  }
+
+  return titles
+}
+
+test('router permission action titles use locale keys', () => {
+  const titles = collectAuthListTitles([shopRoutes, srpRoutes, systemRoutes])
+
+  assert.deepEqual(
+    titles.filter(({ title }) => /[\u4e00-\u9fff]/u.test(title)),
+    []
+  )
+  assert.deepEqual(
+    titles.filter(({ title }) => !title.startsWith('authActions.')),
+    []
+  )
+  assert.deepEqual(
+    titles.filter(
+      ({ title }) =>
+        typeof getLocaleValue(zhMessages, title) !== 'string' ||
+        typeof getLocaleValue(enMessages, title) !== 'string'
+    ),
+    []
+  )
+})
 
 test('applyMenuAccessFilter hides requiresNewbro routes when status is unknown', () => {
   const filtered = applyMenuAccessFilter(newbroRoutes, ['user'], undefined)

--- a/static/src/router/guards/beforeEach.ts
+++ b/static/src/router/guards/beforeEach.ts
@@ -320,7 +320,7 @@ async function handleDynamicRoutes(
 
     // 3. 验证菜单数据
     if (!menuProcessor.validateMenuList(menuList)) {
-      throw new Error('获取菜单列表失败，请重新登录')
+      throw new Error($t('route.menuListFailed'))
     }
 
     // 4. 注册动态路由

--- a/static/src/router/modules/shop.ts
+++ b/static/src/router/modules/shop.ts
@@ -28,9 +28,9 @@ export const shopRoutes: AppRouteRecord = {
         keepAlive: true,
         roles: ['super_admin', 'admin'],
         authList: [
-          { title: '新增商品', authMark: 'add_product' },
-          { title: '编辑商品', authMark: 'edit_product' },
-          { title: '删除商品', authMark: 'delete_product' }
+          { title: 'authActions.shop.addProduct', authMark: 'add_product' },
+          { title: 'authActions.shop.editProduct', authMark: 'edit_product' },
+          { title: 'authActions.shop.deleteProduct', authMark: 'delete_product' }
         ]
       }
     },
@@ -42,7 +42,7 @@ export const shopRoutes: AppRouteRecord = {
         title: 'menus.shop.orderManage',
         keepAlive: true,
         roles: ['super_admin', 'admin', 'shop_order_manage'],
-        authList: [{ title: '审批订单', authMark: 'approve_order' }]
+        authList: [{ title: 'authActions.shop.approveOrder', authMark: 'approve_order' }]
       }
     },
     {

--- a/static/src/router/modules/srp.ts
+++ b/static/src/router/modules/srp.ts
@@ -28,7 +28,7 @@ export const srpRoutes: AppRouteRecord = {
         title: 'menus.srp.srpManage',
         keepAlive: true,
         roles: ['super_admin', 'admin', 'senior_fc', 'srp'],
-        authList: [{ title: '审批', authMark: 'approve' }]
+        authList: [{ title: 'authActions.srp.approve', authMark: 'approve' }]
       }
     },
     {

--- a/static/src/router/modules/system.ts
+++ b/static/src/router/modules/system.ts
@@ -19,8 +19,8 @@ export const systemRoutes: AppRouteRecord = {
         keepAlive: true,
         roles: ['super_admin', 'admin'],
         authList: [
-          { title: '删除用户', authMark: 'delete_user' },
-          { title: '分配职权', authMark: 'assign_role' }
+          { title: 'authActions.system.deleteUser', authMark: 'delete_user' },
+          { title: 'authActions.system.assignRole', authMark: 'assign_role' }
         ]
       }
     },
@@ -33,8 +33,8 @@ export const systemRoutes: AppRouteRecord = {
         keepAlive: true,
         roles: ['super_admin', 'admin'],
         authList: [
-          { title: '执行任务', authMark: 'execute_task' },
-          { title: '修改调度', authMark: 'update_schedule' }
+          { title: 'authActions.system.executeTask', authMark: 'execute_task' },
+          { title: 'authActions.system.updateSchedule', authMark: 'update_schedule' }
         ]
       }
     },
@@ -47,8 +47,8 @@ export const systemRoutes: AppRouteRecord = {
         keepAlive: true,
         roles: ['super_admin', 'admin'],
         authList: [
-          { title: '调整余额', authMark: 'adjust_balance' },
-          { title: '查看日志', authMark: 'view_log' }
+          { title: 'authActions.system.adjustBalance', authMark: 'adjust_balance' },
+          { title: 'authActions.system.viewLog', authMark: 'view_log' }
         ]
       }
     },
@@ -60,7 +60,7 @@ export const systemRoutes: AppRouteRecord = {
         title: 'menus.system.audit',
         keepAlive: true,
         roles: ['super_admin', 'admin'],
-        authList: [{ title: '查看审计明细', authMark: 'view_audit_detail' }]
+        authList: [{ title: 'authActions.system.viewAuditDetail', authMark: 'view_audit_detail' }]
       }
     },
     {
@@ -71,7 +71,7 @@ export const systemRoutes: AppRouteRecord = {
         title: 'menus.system.papExchange',
         keepAlive: true,
         roles: ['super_admin', 'admin'],
-        authList: [{ title: '编辑兑换率', authMark: 'edit_exchange_rate' }]
+        authList: [{ title: 'authActions.system.editExchangeRate', authMark: 'edit_exchange_rate' }]
       }
     },
     {
@@ -82,7 +82,7 @@ export const systemRoutes: AppRouteRecord = {
         title: 'menus.system.alliancePap',
         keepAlive: true,
         roles: ['super_admin', 'admin'],
-        authList: [{ title: '手动拉取', authMark: 'manual_fetch' }]
+        authList: [{ title: 'authActions.system.manualFetch', authMark: 'manual_fetch' }]
       }
     },
     {

--- a/static/src/utils/storage/storage.ts
+++ b/static/src/utils/storage/storage.ts
@@ -35,6 +35,7 @@
 import { router } from '@/router'
 import { useUserStore } from '@/store/modules/user'
 import { StorageConfig } from '@/utils/storage/storage-config'
+import { $t } from '@/locales'
 
 /**
  * 存储兼容性管理器
@@ -101,7 +102,7 @@ class StorageCompatibilityManager {
       type: 'error',
       offset: 40,
       duration: 5000,
-      message: '系统检测到本地数据异常，请重新登录系统恢复使用！'
+      message: $t('storage.invalidLocalData')
     })
   }
 

--- a/static/src/utils/table/tableUtils.ts
+++ b/static/src/utils/table/tableUtils.ts
@@ -272,7 +272,8 @@ export const createSmartDebounce = <T extends (...args: any[]) => Promise<any>>(
  */
 export const createErrorHandler = (
   onError?: (error: TableError) => void,
-  enableLog: boolean = false
+  enableLog: boolean = false,
+  unknownMessage: string = 'Unknown error'
 ) => {
   const logger = {
     error: (message: string, ...args: any[]) => {
@@ -283,7 +284,7 @@ export const createErrorHandler = (
   return (err: unknown, context: string): TableError => {
     const tableError: TableError = {
       code: 'UNKNOWN_ERROR',
-      message: '未知错误',
+      message: unknownMessage,
       details: err
     }
 

--- a/static/src/utils/ui/colors.ts
+++ b/static/src/utils/ui/colors.ts
@@ -42,6 +42,7 @@
  * @author Art Design Pro Team
  */
 import { useSettingStore } from '@/store/modules/setting'
+import { $t } from '@/locales'
 
 /**
  * 颜色转换结果接口
@@ -125,7 +126,7 @@ export function hexToRgba(hex: string, opacity: number): RgbaResult {
  */
 export function hexToRgb(hexColor: string): number[] {
   if (!isValidHexColor(hexColor)) {
-    ElMessage.warning('输入错误的hex颜色值')
+    ElMessage.warning($t('color.invalidHex'))
     throw new Error('Invalid hex color format')
   }
 
@@ -157,7 +158,7 @@ export function hexToRgb(hexColor: string): number[] {
  */
 export function rgbToHex(r: number, g: number, b: number): string {
   if (!isValidRgbValue(r, g, b)) {
-    ElMessage.warning('输入错误的RGB颜色值')
+    ElMessage.warning($t('color.invalidRgb'))
     throw new Error('Invalid RGB color values')
   }
 
@@ -199,7 +200,7 @@ export function colourBlend(color1: string, color2: string, ratio: number): stri
  */
 export function getLightColor(color: string, level: number, isDark: boolean = false): string {
   if (!isValidHexColor(color)) {
-    ElMessage.warning('输入错误的hex颜色值')
+    ElMessage.warning($t('color.invalidHex'))
     throw new Error('Invalid hex color format')
   }
 
@@ -221,7 +222,7 @@ export function getLightColor(color: string, level: number, isDark: boolean = fa
  */
 export function getDarkColor(color: string, level: number): string {
   if (!isValidHexColor(color)) {
-    ElMessage.warning('输入错误的hex颜色值')
+    ElMessage.warning($t('color.invalidHex'))
     throw new Error('Invalid hex color format')
   }
 

--- a/static/src/views/auth/register/index.vue
+++ b/static/src/views/auth/register/index.vue
@@ -205,7 +205,7 @@
       // 模拟注册请求
       setTimeout(() => {
         loading.value = false
-        ElMessage.success('注册成功')
+        ElMessage.success(t('register.success'))
         toLogin()
       }, REDIRECT_DELAY)
     } catch (error) {

--- a/static/src/views/dashboard/console/index.vue
+++ b/static/src/views/dashboard/console/index.vue
@@ -49,7 +49,7 @@
     try {
       dashboardData.value = await fetchDashboard()
     } catch (e) {
-      console.error('加载工作台数据失败', e)
+      console.error(t('console.dashboardLoadFailedLog'), e)
     } finally {
       loading.value = false
     }

--- a/static/src/views/info/skill/index.test.ts
+++ b/static/src/views/info/skill/index.test.ts
@@ -6,7 +6,7 @@ const source = readFileSync(new URL('./index.vue', import.meta.url), 'utf8')
 
 test('skill page renders ESI refresh button alongside database refresh button', () => {
   assert.match(source, /<ElButton[\s\S]*:loading="loading"[\s\S]*@click="loadData"/)
-  assert.match(source, /<ElButton[\s\S]*:loading="esiRefreshing"[\s\S]*ESI 拉取/)
+  assert.match(source, /<ElButton[\s\S]*:loading="esiRefreshing"[\s\S]*info\.esiRefreshButton/)
   assert.match(source, /const esiRefreshing = ref\(false\)/)
 })
 
@@ -19,17 +19,17 @@ test('ESI refresh button calls runMyCharacterESIRefresh with correct parameters'
 
 test('ESI refresh button shows confirmation dialog before submission', () => {
   assert.match(source, /await ElMessageBox\.confirm\(/)
-  assert.match(source, /确认从 ESI 拉取角色/)
-  assert.match(source, /confirmButtonText: '确认拉取'/)
-  assert.match(source, /cancelButtonText: '取消'/)
+  assert.match(source, /info\.skillESIRefreshConfirm/)
+  assert.match(source, /confirmButtonText: t\('info\.esiRefreshConfirmButton'\)/)
+  assert.match(source, /cancelButtonText: t\('common\.cancel'\)/)
   assert.match(source, /type: 'info'/)
 })
 
 test('ESI refresh button differentiates permission errors from other errors', () => {
-  assert.match(source, /if \(msg\.includes\('无权'\) \|\| e\?\.response\?\.status === 403\)/)
-  assert.match(source, /ElMessage\.error\('无权操作此角色'\)/)
+  assert.match(source, /if \(msg\.includes\('无权'\) \|\| error\.response\?\.status === 403\)/)
+  assert.match(source, /ElMessage\.error\(t\('info\.esiRefreshUnauthorized'\)\)/)
   assert.match(source, /else if \(msg\.includes\('角色不存在'\)\)/)
-  assert.match(source, /ElMessage\.error\('角色未找到'\)/)
+  assert.match(source, /ElMessage\.error\(t\('info\.esiRefreshCharacterNotFound'\)\)/)
 })
 
 test('ESI refresh button displays loading state during submission', () => {
@@ -38,8 +38,5 @@ test('ESI refresh button displays loading state during submission', () => {
 })
 
 test('ESI refresh success message instructs user to refresh page', () => {
-  assert.match(
-    source,
-    /ElMessage\.success\('技能数据 ESI 刷新任务已提交，稍后可点击刷新按钮查看最新数据'\)/
-  )
+  assert.match(source, /ElMessage\.success\(t\('info\.skillESIRefreshSubmitted'\)\)/)
 })

--- a/static/src/views/info/skill/index.vue
+++ b/static/src/views/info/skill/index.vue
@@ -35,7 +35,7 @@
             @click="onESIRefreshClick"
           >
             <el-icon class="mr-1"><Download /></el-icon>
-            ESI 拉取
+            {{ $t('info.esiRefreshButton') }}
           </ElButton>
         </div>
       </div>
@@ -235,10 +235,12 @@
   import { fetchInfoSkills, runMyCharacterESIRefresh } from '@/api/eve-info'
   import { useUserStore } from '@/store/modules/user'
   import { buildEveCharacterPortraitUrl } from '@/utils/eve-image'
+  import { useI18n } from 'vue-i18n'
 
   defineOptions({ name: 'EveInfoSkill' })
 
   const userStore = useUserStore()
+  const { t } = useI18n()
 
   // ---- 数据 ----
   const characters = ref<Api.Auth.EveCharacter[]>([])
@@ -261,7 +263,7 @@
     if (!finishDate) return ''
     const now = Math.floor(Date.now() / 1000)
     let remaining = finishDate - now
-    if (remaining <= 0) return '已完成'
+    if (remaining <= 0) return t('info.trainingComplete')
     const days = Math.floor(remaining / 86400)
     remaining %= 86400
     const hours = Math.floor(remaining / 3600)
@@ -269,11 +271,13 @@
     const minutes = Math.floor(remaining / 60)
     const seconds = remaining % 60
     let result = ''
-    if (days > 0) result += `${days}天 `
-    if (hours > 0 || days > 0) result += `${hours}小时`
+    if (days > 0) result += `${t('info.durationDays', { count: days })} `
+    if (hours > 0 || days > 0) result += t('info.durationHours', { count: hours })
     if (days === 0) {
-      if (minutes > 0) result += ` ${minutes}分`
-      if (hours === 0 && minutes < 10) result += ` ${seconds}秒`
+      if (minutes > 0) result += ` ${t('info.durationMinutes', { count: minutes })}`
+      if (hours === 0 && minutes < 10) {
+        result += ` ${t('info.durationSeconds', { count: seconds })}`
+      }
     }
     return result.trim()
   }
@@ -413,11 +417,15 @@
     const charName = char?.character_name || String(selectedCharacterId.value)
 
     try {
-      await ElMessageBox.confirm(`确认从 ESI 拉取角色「${charName}」的技能数据？`, 'ESI 拉取', {
-        confirmButtonText: '确认拉取',
-        cancelButtonText: '取消',
-        type: 'info'
-      })
+      await ElMessageBox.confirm(
+        t('info.skillESIRefreshConfirm', { name: charName }),
+        t('info.esiRefreshTitle'),
+        {
+          confirmButtonText: t('info.esiRefreshConfirmButton'),
+          cancelButtonText: t('common.cancel'),
+          type: 'info'
+        }
+      )
     } catch {
       return
     }
@@ -428,13 +436,17 @@
         task_name: 'character_skill',
         character_id: selectedCharacterId.value
       })
-      ElMessage.success('技能数据 ESI 刷新任务已提交，稍后可点击刷新按钮查看最新数据')
-    } catch (e: any) {
-      const msg = e?.response?.data?.message || e?.message || 'ESI 刷新任务提交失败'
-      if (msg.includes('无权') || e?.response?.status === 403) {
-        ElMessage.error('无权操作此角色')
+      ElMessage.success(t('info.skillESIRefreshSubmitted'))
+    } catch (e: unknown) {
+      const error = e as {
+        response?: { data?: { message?: string }; status?: number }
+        message?: string
+      }
+      const msg = error.response?.data?.message || error.message || t('info.esiRefreshSubmitFailed')
+      if (msg.includes('无权') || error.response?.status === 403) {
+        ElMessage.error(t('info.esiRefreshUnauthorized'))
       } else if (msg.includes('角色不存在')) {
-        ElMessage.error('角色未找到')
+        ElMessage.error(t('info.esiRefreshCharacterNotFound'))
       } else {
         ElMessage.error(msg)
       }

--- a/static/src/views/info/wallet/index.vue
+++ b/static/src/views/info/wallet/index.vue
@@ -31,7 +31,7 @@
             @click="onESIRefreshClick"
           >
             <el-icon class="mr-1"><Download /></el-icon>
-            ESI 拉取
+            {{ $t('info.esiRefreshButton') }}
           </ElButton>
           <span class="text-sm text-gray-500">{{ $t('info.journalTypeFilter') }}</span>
           <ElSelect
@@ -256,11 +256,15 @@
     const charName = char?.character_name || String(selectedCharacterId.value)
 
     try {
-      await ElMessageBox.confirm(`确认从 ESI 拉取角色「${charName}」的钱包数据？`, 'ESI 拉取', {
-        confirmButtonText: '确认拉取',
-        cancelButtonText: '取消',
-        type: 'info'
-      })
+      await ElMessageBox.confirm(
+        t('info.walletESIRefreshConfirm', { name: charName }),
+        t('info.esiRefreshTitle'),
+        {
+          confirmButtonText: t('info.esiRefreshConfirmButton'),
+          cancelButtonText: t('common.cancel'),
+          type: 'info'
+        }
+      )
     } catch {
       return
     }
@@ -271,13 +275,17 @@
         task_name: 'character_wallet',
         character_id: selectedCharacterId.value
       })
-      ElMessage.success('钱包数据 ESI 刷新任务已提交，稍后可点击刷新按钮查看最新数据')
-    } catch (e: any) {
-      const msg = e?.response?.data?.message || e?.message || 'ESI 刷新任务提交失败'
-      if (msg.includes('无权') || e?.response?.status === 403) {
-        ElMessage.error('无权操作此角色')
+      ElMessage.success(t('info.walletESIRefreshSubmitted'))
+    } catch (e: unknown) {
+      const error = e as {
+        response?: { data?: { message?: string }; status?: number }
+        message?: string
+      }
+      const msg = error.response?.data?.message || error.message || t('info.esiRefreshSubmitFailed')
+      if (msg.includes('无权') || error.response?.status === 403) {
+        ElMessage.error(t('info.esiRefreshUnauthorized'))
       } else if (msg.includes('角色不存在')) {
-        ElMessage.error('角色未找到')
+        ElMessage.error(t('info.esiRefreshCharacterNotFound'))
       } else {
         ElMessage.error(msg)
       }

--- a/static/src/views/srp/manage/index.test.ts
+++ b/static/src/views/srp/manage/index.test.ts
@@ -33,8 +33,12 @@ test('srp batch payout copy text keeps exact ISK values instead of smart-abbrevi
 test('srp manage labels the last actor as the SRP officer after the review note column', () => {
   const reviewNoteColumnIndex = manageHookSource.indexOf("prop: 'review_note'")
   const lastActorColumnIndex = manageHookSource.indexOf("prop: 'last_actor_nickname'")
-  const reviewNoteHeaderIndex = manageHookSource.indexOf("review_note: '审批备注'")
-  const lastActorHeaderIndex = manageHookSource.indexOf("last_actor_nickname: '补损官'")
+  const reviewNoteHeaderIndex = manageHookSource.indexOf(
+    "review_note: t('srp.manage.exportColumns.reviewNote')"
+  )
+  const lastActorHeaderIndex = manageHookSource.indexOf(
+    "last_actor_nickname: t('srp.manage.exportColumns.lastActor')"
+  )
   const reviewNoteExportIndex = manageHookSource.indexOf("review_note: app.review_note || '-'")
   const lastActorExportIndex = manageHookSource.indexOf(
     "last_actor_nickname: app.last_actor_nickname || '-'"
@@ -53,4 +57,6 @@ test('srp manage labels the last actor as the SRP officer after the review note 
   assert.match(manageHookSource, /label:\s*t\('srp\.manage\.columns\.lastActor'\)/)
   assert.equal(zhLocale.srp.manage.columns.lastActor, '补损官')
   assert.equal(enLocale.srp.manage.columns.lastActor, 'SRP Officer')
+  assert.equal(zhLocale.srp.manage.exportColumns.lastActor, '补损官')
+  assert.equal(enLocale.srp.manage.exportColumns.lastActor, 'SRP Officer')
 })

--- a/static/src/views/srp/manage/index.vue
+++ b/static/src/views/srp/manage/index.vue
@@ -75,7 +75,7 @@
                 :data="exportManageData"
                 :headers="manageExportHeaders"
                 :filename="`srp-manage_${new Date().toLocaleDateString()}`"
-                sheet-name="补损申请"
+                :sheet-name="$t('srp.manage.exportSheetName')"
                 :button-text="$t('srp.manage.exportBtn')"
                 type="success"
               />
@@ -320,6 +320,8 @@
     ElRadioGroup,
     ElRadioButton
   } from 'element-plus'
+  import ArtButtonTable from '@/components/core/forms/art-button-table/index.vue'
+  import ArtCopyButton from '@/components/core/forms/art-copy-button/index.vue'
   import ArtExcelExport from '@/components/core/forms/art-excel-export/index.vue'
   import KmPreviewDialog from '@/components/business/KmPreviewDialog.vue'
   import { CopyDocument } from '@element-plus/icons-vue'
@@ -358,7 +360,11 @@
   } = useSrpManage({
     openReviewDialog: (...args) => openReviewDialog(...args),
     handlePayoutAction: (...args) => handlePayoutAction(...args),
-    openKmPreview: (row) => openKmPreview(row)
+    openKmPreview: (row) => openKmPreview(row),
+    components: {
+      ArtButtonTable,
+      ArtCopyButton
+    }
   })
 
   const {

--- a/static/src/views/system/basic-config/index.vue
+++ b/static/src/views/system/basic-config/index.vue
@@ -140,6 +140,7 @@
     updateAllowCorporations
   } from '@/api/sys-config'
   import { SYSTEM_IDENTITY, SYSTEM_IDENTITY_I18N } from '@/constants/system-identity'
+  import { formatTime } from '@/utils/common'
 
   defineOptions({ name: 'BasicConfig' })
 
@@ -242,7 +243,7 @@
     if (!unixSeconds) {
       return '-'
     }
-    return new Date(unixSeconds * 1000).toLocaleString()
+    return formatTime(new Date(unixSeconds * 1000).toISOString())
   }
 
   const handleSaveSDE = async () => {

--- a/static/src/views/system/pap/modules/pap-search.vue
+++ b/static/src/views/system/pap/modules/pap-search.vue
@@ -62,15 +62,15 @@
   import { Download } from '@element-plus/icons-vue'
   import { ElButton, type FormInstance, type FormRules } from 'element-plus'
   import { useI18n } from 'vue-i18n'
-  import axios from 'axios'
+  import { fetchSeatPapTracking } from '@/api/alliance-pap'
 
   interface Props {
-    modelValue: Record<string, any>
+    modelValue: Record<string, unknown>
     fetching?: boolean
   }
   interface Emits {
-    (e: 'update:modelValue', value: Record<string, any>): void
-    (e: 'search', params: Record<string, any>): void
+    (e: 'update:modelValue', value: Record<string, unknown>): void
+    (e: 'search', params: Record<string, unknown>): void
     (e: 'reset'): void
     (e: 'fetch'): void
     (e: 'import', rows: Record<string, unknown>[]): void
@@ -160,58 +160,19 @@
     dialogVisible.value = true
   }
 
-  const { VITE_API_URL } = import.meta.env
-
   async function handleImportSEAT() {
     if (!formRef.value) return
     await formRef.value.validate()
 
-    let rows: Record<string, unknown>[] = []
+    const rows: Record<string, unknown>[] = []
 
     submitLoading.value = true
     try {
-      /* 创建Axios实例 */
-      const axiosInstance = axios.create({
-        timeout: 10000,
-        baseURL: VITE_API_URL,
-        // SECURITY WARNING:
-        // The X-Cookie header below intentionally contains real session tokens
-        // (laravel_session and optionally cf_clearance) that are
-        // proxied through our backend/Nginx to the SEAT server.
-        //
-        // These credentials MUST be treated as highly sensitive:
-        //   - Backend/proxy access logs MUST NOT record the X-Cookie header.
-        //   - Any request/response logging or tracing MUST redact or omit
-        //     the values of this header.
-        //   - Only HTTPS should be used for this request.
-        //
-        // Changing this behavior will break SEAT integration; if you need
-        // to modify it, coordinate with security and infrastructure teams.
-        headers: {
-          Accept: 'application/json, text/javascript, */*; q=0.01',
-          'X-Accept-Encoding': 'gzip, deflate, br, zstd',
-          'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',
-          'Cache-Control': 'no-cache',
-          'X-Cookie':
-            `laravel_session=${formDataSEAT.laravelSession}` +
-            (formDataSEAT.cfClearance === '' ? '' : `;cf_clearance=${formDataSEAT.cfClearance}`),
-          Pragma: 'no-cache',
-          Priority: 'u=1, i',
-          'X-Sec-Ch-Ua': `"Not:A-Brand";v="99", "Microsoft Edge";v="145", "Chromium";v="145"`,
-          'X-Sec-Ch-Ua-Mobile': '?0',
-          'X-Sec-Ch-Ua-Platform': `"Windows"`,
-          'X-Sec-Fetch-Dest': 'empty',
-          'X-Sec-Fetch-Mode': 'cors',
-          'X-Sec-Fetch-Site': 'same-origin',
-          'X-User-Agent':
-            formDataSEAT.UA === ''
-              ? 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
-              : formDataSEAT.UA,
-          'X-Requested-With': 'XMLHttpRequest'
-        }
+      const response = await fetchSeatPapTracking({
+        laravelSession: formDataSEAT.laravelSession,
+        cfClearance: formDataSEAT.cfClearance,
+        userAgent: formDataSEAT.UA
       })
-
-      const response = await axiosInstance.get('/seatproxy/tools/paptracking')
 
       if (response.status == 200 && response.data.data) {
         for (const item of response.data.data) {
@@ -228,8 +189,8 @@
 
       dialogVisible.value = false
       emit('import', rows)
-    } catch (e: any) {
-      ElMessage.error(e?.message ?? t('common.error'))
+    } catch (e: unknown) {
+      ElMessage.error(e instanceof Error ? e.message : t('common.error'))
     } finally {
       submitLoading.value = false
     }

--- a/static/src/views/system/user-center/index.vue
+++ b/static/src/views/system/user-center/index.vue
@@ -10,7 +10,7 @@
             src="@imgs/user/avatar.webp"
           />
           <h2 class="mt-5 text-xl font-normal">{{ userInfo.userName }}</h2>
-          <p class="mt-5 text-sm">专注于用户体验跟视觉设计</p>
+          <p class="mt-5 text-sm">{{ $t('userCenter.profile.bio') }}</p>
 
           <div class="w-75 mx-auto mt-7.5 text-left">
             <div class="mt-2.5">
@@ -19,23 +19,23 @@
             </div>
             <div class="mt-2.5">
               <ArtSvgIcon icon="ri:user-3-line" class="text-g-700" />
-              <span class="ml-2 text-sm">交互专家</span>
+              <span class="ml-2 text-sm">{{ $t('userCenter.profile.role') }}</span>
             </div>
             <div class="mt-2.5">
               <ArtSvgIcon icon="ri:map-pin-line" class="text-g-700" />
-              <span class="ml-2 text-sm">广东省深圳市</span>
+              <span class="ml-2 text-sm">{{ $t('userCenter.profile.location') }}</span>
             </div>
             <div class="mt-2.5">
               <ArtSvgIcon icon="ri:dribbble-fill" class="text-g-700" />
-              <span class="ml-2 text-sm">字节跳动－某某平台部－UED</span>
+              <span class="ml-2 text-sm">{{ $t('userCenter.profile.organization') }}</span>
             </div>
           </div>
 
           <div class="mt-10">
-            <h3 class="text-sm font-medium">标签</h3>
+            <h3 class="text-sm font-medium">{{ $t('userCenter.sections.tags') }}</h3>
             <div class="flex flex-wrap justify-center mt-3.5">
               <div
-                v-for="item in lableList"
+                v-for="item in labelList"
                 :key="item"
                 class="py-1 px-1.5 mr-2.5 mb-2.5 text-xs border border-g-300 rounded"
               >
@@ -47,7 +47,9 @@
       </div>
       <div class="flex-1 overflow-hidden max-md:w-full max-md:mt-3.5">
         <div class="art-card-sm">
-          <h1 class="p-4 text-xl font-normal border-b border-g-300">基本设置</h1>
+          <h1 class="p-4 text-xl font-normal border-b border-g-300">
+            {{ $t('userCenter.sections.basicSettings') }}
+          </h1>
 
           <ElForm
             :model="form"
@@ -58,11 +60,15 @@
             label-position="top"
           >
             <ElRow>
-              <ElFormItem label="姓名" prop="realName">
+              <ElFormItem :label="$t('userCenter.fields.realName')" prop="realName">
                 <ElInput v-model="form.realName" :disabled="!isEdit" />
               </ElFormItem>
-              <ElFormItem label="性别" prop="sex" class="ml-5">
-                <ElSelect v-model="form.sex" placeholder="Select" :disabled="!isEdit">
+              <ElFormItem :label="$t('userCenter.fields.sex')" prop="sex" class="ml-5">
+                <ElSelect
+                  v-model="form.sex"
+                  :placeholder="$t('userCenter.fields.sexPlaceholder')"
+                  :disabled="!isEdit"
+                >
                   <ElOption
                     v-for="item in options"
                     :key="item.value"
@@ -74,40 +80,42 @@
             </ElRow>
 
             <ElRow>
-              <ElFormItem label="昵称" prop="nikeName">
+              <ElFormItem :label="$t('userCenter.fields.nickName')" prop="nikeName">
                 <ElInput v-model="form.nikeName" :disabled="!isEdit" />
               </ElFormItem>
-              <ElFormItem label="邮箱" prop="email" class="ml-5">
+              <ElFormItem :label="$t('userCenter.fields.email')" prop="email" class="ml-5">
                 <ElInput v-model="form.email" :disabled="!isEdit" />
               </ElFormItem>
             </ElRow>
 
             <ElRow>
-              <ElFormItem label="手机" prop="mobile">
+              <ElFormItem :label="$t('userCenter.fields.mobile')" prop="mobile">
                 <ElInput v-model="form.mobile" :disabled="!isEdit" />
               </ElFormItem>
-              <ElFormItem label="地址" prop="address" class="ml-5">
+              <ElFormItem :label="$t('userCenter.fields.address')" prop="address" class="ml-5">
                 <ElInput v-model="form.address" :disabled="!isEdit" />
               </ElFormItem>
             </ElRow>
 
-            <ElFormItem label="个人介绍" prop="des" class="h-32">
+            <ElFormItem :label="$t('userCenter.fields.description')" prop="des" class="h-32">
               <ElInput type="textarea" :rows="4" v-model="form.des" :disabled="!isEdit" />
             </ElFormItem>
 
             <div class="flex-c justify-end [&_.el-button]:!w-27.5">
               <ElButton type="primary" class="w-22.5" v-ripple @click="edit">
-                {{ isEdit ? '保存' : '编辑' }}
+                {{ isEdit ? $t('common.save') : $t('common.edit') }}
               </ElButton>
             </div>
           </ElForm>
         </div>
 
         <div class="art-card-sm my-5">
-          <h1 class="p-4 text-xl font-normal border-b border-g-300">更改密码</h1>
+          <h1 class="p-4 text-xl font-normal border-b border-g-300">
+            {{ $t('userCenter.sections.changePassword') }}
+          </h1>
 
           <ElForm :model="pwdForm" class="box-border p-5" label-width="86px" label-position="top">
-            <ElFormItem label="当前密码" prop="password">
+            <ElFormItem :label="$t('userCenter.fields.currentPassword')" prop="password">
               <ElInput
                 v-model="pwdForm.password"
                 type="password"
@@ -116,7 +124,7 @@
               />
             </ElFormItem>
 
-            <ElFormItem label="新密码" prop="newPassword">
+            <ElFormItem :label="$t('userCenter.fields.newPassword')" prop="newPassword">
               <ElInput
                 v-model="pwdForm.newPassword"
                 type="password"
@@ -125,7 +133,7 @@
               />
             </ElFormItem>
 
-            <ElFormItem label="确认新密码" prop="confirmPassword">
+            <ElFormItem :label="$t('userCenter.fields.confirmPassword')" prop="confirmPassword">
               <ElInput
                 v-model="pwdForm.confirmPassword"
                 type="password"
@@ -136,7 +144,7 @@
 
             <div class="flex-c justify-end [&_.el-button]:!w-27.5">
               <ElButton type="primary" class="w-22.5" v-ripple @click="editPwd">
-                {{ isEditPwd ? '保存' : '编辑' }}
+                {{ isEditPwd ? $t('common.save') : $t('common.edit') }}
               </ElButton>
             </div>
           </ElForm>
@@ -147,11 +155,13 @@
 </template>
 
 <script setup lang="ts">
+  import { useI18n } from 'vue-i18n'
   import { useUserStore } from '@/store/modules/user'
   import type { FormInstance, FormRules } from 'element-plus'
 
   defineOptions({ name: 'UserCenter' })
 
+  const { t } = useI18n()
   const userStore = useUserStore()
   const userInfo = computed(() => userStore.getUserInfo)
 
@@ -165,12 +175,12 @@
    */
   const form = reactive({
     realName: 'John Snow',
-    nikeName: '皮卡丘',
+    nikeName: t('userCenter.profile.nickname'),
     email: '59301283@mall.com',
     mobile: '18888888888',
-    address: '广东省深圳市宝安区西乡街道101栋201',
+    address: t('userCenter.profile.address'),
     sex: '2',
-    des: 'Art Design Pro 是一款兼具设计美学与高效开发的后台系统.'
+    des: t('userCenter.profile.description')
   })
 
   /**
@@ -185,33 +195,44 @@
   /**
    * 表单验证规则
    */
-  const rules = reactive<FormRules>({
+  const rules = computed<FormRules>(() => ({
     realName: [
-      { required: true, message: '请输入姓名', trigger: 'blur' },
-      { min: 2, max: 50, message: '长度在 2 到 50 个字符', trigger: 'blur' }
+      { required: true, message: t('userCenter.validation.realNameRequired'), trigger: 'blur' },
+      { min: 2, max: 50, message: t('userCenter.validation.length2To50'), trigger: 'blur' }
     ],
     nikeName: [
-      { required: true, message: '请输入昵称', trigger: 'blur' },
-      { min: 2, max: 50, message: '长度在 2 到 50 个字符', trigger: 'blur' }
+      { required: true, message: t('userCenter.validation.nickNameRequired'), trigger: 'blur' },
+      { min: 2, max: 50, message: t('userCenter.validation.length2To50'), trigger: 'blur' }
     ],
-    email: [{ required: true, message: '请输入邮箱', trigger: 'blur' }],
-    mobile: [{ required: true, message: '请输入手机号码', trigger: 'blur' }],
-    address: [{ required: true, message: '请输入地址', trigger: 'blur' }],
-    sex: [{ required: true, message: '请选择性别', trigger: 'blur' }]
-  })
+    email: [{ required: true, message: t('userCenter.validation.emailRequired'), trigger: 'blur' }],
+    mobile: [
+      { required: true, message: t('userCenter.validation.mobileRequired'), trigger: 'blur' }
+    ],
+    address: [
+      { required: true, message: t('userCenter.validation.addressRequired'), trigger: 'blur' }
+    ],
+    sex: [{ required: true, message: t('userCenter.validation.sexRequired'), trigger: 'blur' }]
+  }))
 
   /**
    * 性别选项
    */
-  const options = [
-    { value: '1', label: '男' },
-    { value: '2', label: '女' }
-  ]
+  const options = computed(() => [
+    { value: '1', label: t('userCenter.sex.male') },
+    { value: '2', label: t('userCenter.sex.female') }
+  ])
 
   /**
    * 用户标签列表
    */
-  const lableList: Array<string> = ['专注设计', '很有想法', '辣~', '大长腿', '川妹子', '海纳百川']
+  const labelList = computed(() => [
+    t('userCenter.tags.design'),
+    t('userCenter.tags.creative'),
+    t('userCenter.tags.bold'),
+    t('userCenter.tags.tall'),
+    t('userCenter.tags.sichuan'),
+    t('userCenter.tags.inclusive')
+  ])
 
   onMounted(() => {
     getDate()
@@ -223,12 +244,12 @@
   const getDate = () => {
     const h = new Date().getHours()
 
-    if (h >= 6 && h < 9) date.value = '早上好'
-    else if (h >= 9 && h < 11) date.value = '上午好'
-    else if (h >= 11 && h < 13) date.value = '中午好'
-    else if (h >= 13 && h < 18) date.value = '下午好'
-    else if (h >= 18 && h < 24) date.value = '晚上好'
-    else date.value = '很晚了，早点睡'
+    if (h >= 6 && h < 9) date.value = t('userCenter.greetings.earlyMorning')
+    else if (h >= 9 && h < 11) date.value = t('userCenter.greetings.morning')
+    else if (h >= 11 && h < 13) date.value = t('userCenter.greetings.noon')
+    else if (h >= 13 && h < 18) date.value = t('userCenter.greetings.afternoon')
+    else if (h >= 18 && h < 24) date.value = t('userCenter.greetings.evening')
+    else date.value = t('userCenter.greetings.lateNight')
   }
 
   /**

--- a/static/src/views/system/user-facing-text.test.ts
+++ b/static/src/views/system/user-facing-text.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const pages = [
+  new URL('./user-center/index.vue', import.meta.url),
+  new URL('./webhook/index.vue', import.meta.url),
+  new URL('./wallet/modules/wallet-logs.vue', import.meta.url)
+]
+
+function findHardcodedChinese(source: string) {
+  const template = stripComments(source.match(/<template>([\s\S]*?)<\/template>/)?.[1] ?? '')
+  const script = stripComments(source.match(/<script[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? '')
+
+  return [
+    ...(template.match(/(?:label|placeholder|title)="[^"]*[\u4e00-\u9fff][^"]*"/g) ?? []),
+    ...(template.match(/>[^<]*[\u4e00-\u9fff][^<]*</g) ?? []),
+    ...(script.match(/['"][^'"\n]*[\u4e00-\u9fff][^'"\n]*['"]/g) ?? [])
+  ]
+}
+
+function stripComments(source: string) {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+}
+
+test('system user-facing pages keep Chinese text in locale files', () => {
+  const matches = pages.flatMap((page) =>
+    findHardcodedChinese(readFileSync(page, 'utf8')).map((match) => ({
+      page: page.pathname,
+      match
+    }))
+  )
+
+  assert.deepEqual(matches, [])
+})

--- a/static/src/views/system/wallet/modules/wallet-logs.vue
+++ b/static/src/views/system/wallet/modules/wallet-logs.vue
@@ -85,7 +85,7 @@
         { type: 'index', width: 60, label: '#' },
         {
           prop: 'operator_id',
-          label: '操作人',
+          label: t('walletAdmin.logs.operator'),
           minWidth: 140,
           formatter: (row: WalletLog) =>
             h(
@@ -98,7 +98,7 @@
         },
         {
           prop: 'target_uid',
-          label: '目标用户',
+          label: t('walletAdmin.logs.targetUser'),
           minWidth: 140,
           formatter: (row: WalletLog) =>
             h(

--- a/static/src/views/system/webhook/index.vue
+++ b/static/src/views/system/webhook/index.vue
@@ -21,10 +21,10 @@
         <!-- 类型 -->
         <ElFormItem :label="$t('webhook.fields.type')">
           <ElSelect v-model="form.type" style="width: 220px">
-            <ElOption label="Discord" value="discord" />
-            <ElOption label="飞书 (Feishu)" value="feishu" />
-            <ElOption label="钉钉 (DingTalk)" value="dingtalk" />
-            <ElOption label="OneBot v11 (QQ)" value="onebot" />
+            <ElOption :label="$t('webhook.providers.discord')" value="discord" />
+            <ElOption :label="$t('webhook.providers.feishu')" value="feishu" />
+            <ElOption :label="$t('webhook.providers.dingtalk')" value="dingtalk" />
+            <ElOption :label="$t('webhook.providers.onebot')" value="onebot" />
           </ElSelect>
         </ElFormItem>
 
@@ -101,10 +101,10 @@
       <ElForm label-width="120px" style="max-width: 680px">
         <ElFormItem :label="$t('webhook.test.type')">
           <ElSelect v-model="testForm.type" style="width: 220px">
-            <ElOption label="Discord" value="discord" />
-            <ElOption label="飞书 (Feishu)" value="feishu" />
-            <ElOption label="钉钉 (DingTalk)" value="dingtalk" />
-            <ElOption label="OneBot v11 (QQ)" value="onebot" />
+            <ElOption :label="$t('webhook.providers.discord')" value="discord" />
+            <ElOption :label="$t('webhook.providers.feishu')" value="feishu" />
+            <ElOption :label="$t('webhook.providers.dingtalk')" value="dingtalk" />
+            <ElOption :label="$t('webhook.providers.onebot')" value="onebot" />
           </ElSelect>
         </ElFormItem>
         <ElFormItem :label="$t('webhook.test.url')">

--- a/static/src/views/welfare/my/index.vue
+++ b/static/src/views/welfare/my/index.vue
@@ -6,7 +6,7 @@
         <p class="break-all">
           {{ t('welfareMy.skillPlanningAlertPrefix') }}
           <RouterLink class="text-theme font-medium" :to="{ name: 'SkillPlanCompletionCheck' }">
-            {{ '技能规划-检查完成度' }}
+            {{ t('welfareMy.skillPlanningCheckLink') }}
           </RouterLink>
         </p>
       </ElAlert>


### PR DESCRIPTION
This release moves several backend handlers onto service-layer contracts instead of repository DTOs, adds a dedicated system config service, and localizes the shared frontend copy that was still hardcoded in views and components. It also routes the affected frontend calls through hooks, adds regression tests, and records the 1.8.0 release metadata in the changelog and version files.

这次发布把多个后端处理器改为通过服务层契约而不是直接依赖仓储 DTO，补上了独立的系统配置服务，并将仍然硬编码在视图和组件中的共享前端文案改为本地化文本。它还把相关前端请求收敛到 hooks，补充了回归测试，并在变更日志和版本文件中记录了 1.8.0 发布信息。